### PR TITLE
Set bootstrap-sass-official to require v3.1.1+1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ static/
 python/django/transit_indicators/settings/secret_key.py
 python/django/transit_indicators/settings/provision_settings.py
 python/django/transit_indicators/settings/__init__.py
+geotrellis/src/main/resources/application.conf
 
 # Scala build artifacts
 project/boot

--- a/js/angular/bower.json
+++ b/js/angular/bower.json
@@ -13,7 +13,7 @@
     "angular-translate": "2.1.0",
     "angular-bootstrap": "0.10.0",
     "underscore": "1.6.0",
-    "bootstrap-sass-official": "~3.1.1+1"
+    "bootstrap-sass-official": "3.1.1+1"
   },
   "devDependencies": {
     "angular-mocks": "1.2.15",


### PR DESCRIPTION
Bower install failed with "Could not find tag/branch ~3.1.1+1" on a fresh bower install.

Also gitignores the geotrellis application conf (not picked up by the scala build artifacts line 'resources/application.conf')
