### PR TITLE
Increases the Geotrellis timeout to 2 minutes.

### DIFF
--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -430,6 +430,8 @@ geotrellis.port = \"$GEOTRELLIS_PORT\"
 database.name = \"$DB_NAME\"
 database.user = \"$DB_USER\"
 database.password = \"$DB_PASS\"
+spray.can.server.idle-timeout = 180 s
+spray.can.server.request-timeout = 120 s
 "
 
 pushd $GEOTRELLIS_ROOT/src/main/resources/


### PR DESCRIPTION
So far, the longest any GTFS feed has taken to process is about 30
seconds, which exceeded the default timeout of 20 seconds. However, on slower hardware or with a very large GTFS file, we can expect other feeds to take longer.

Idle-timeout needs to be greater than request-timeout.

This requires re-running the provision script.
