### PR TITLE
Exit create_user mgmt cmd when passed username exists

### DIFF
--- a/python/django/userdata/management/commands/oti_create_user.py
+++ b/python/django/userdata/management/commands/oti_create_user.py
@@ -40,6 +40,12 @@ class Command(BaseCommand):
         email = options['email']
         is_superuser = options['superuser']
 
+        # Ensure a passed username doesn't already exist
+        users = OTIUser.objects.filter(username=username)
+        if users.count() > 0:
+            print "Username taken. Exiting."
+            return
+
         while username is None:
             print 'Please enter a username'
             username = raw_input('Username: ')


### PR DESCRIPTION
This was an oops, my provision failed without this change because the created user already exists.
