### PR TITLE
Add Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ before_script:
   -     npm install --silent > /dev/null
   -     grunt build
   - popd
-notifications:
-  email: false
 env:
   global:
   - secure: JPqVgULkqa5ny9k3+TZsWCJHgG1uP4uMP3shs0VGA7vwVINhJsACBCOmGvTvMX/N7+eZmTlxLJlHZU2MkH0nIyypQ0C71ZkHZURUQ505yqR0n+/8O4HnmVACM1ZnP9YDauy2yAzHVHs9W7ZaqMJym9qyJoqMpY5VEXK35WFPyvk=


### PR DESCRIPTION
By default, email notifications will be sent to the committer and
the commit author, if they are members of the repository (that is,
they have push or admin permissions for public repositories, or if
they have pull, push or admin permissions for private repositories).

And it will by default send emails when, on the given branch:
- a build was just broken or still is broken
- a previously broken build was just fixed
