### PR TITLE
Copy data from Lat/Lon column to UTM column

### DIFF
--- a/geotrellis/src/main/scala/GeoTrellisService.scala
+++ b/geotrellis/src/main/scala/GeoTrellisService.scala
@@ -105,8 +105,14 @@ trait GeoTrellisService extends HttpService {
                    s"TYPE Geometry(${geomType},${srid}) " +
                    s"USING ST_Transform(${column},${srid});").execute
 
+                def geomCopy(srid: Int, table: String, fromColumn: String, toColumn: String) =
+                  (Q.u +
+                   s"UPDATE ${table} SET ${toColumn} = ST_Transform(${fromColumn}, ${srid});").execute
+
                 geomTransform(srid, "gtfs_stops", "Point", "geom")
+                geomCopy(srid, "gtfs_stops", "the_geom", "geom")
                 geomTransform(srid, "gtfs_shape_geoms", "LineString", "geom")
+                geomCopy(srid, "gtfs_shape_geoms", "the_geom", "geom")
 
                 println("Finished transforming to local UTM zone.")
                 JsObject(


### PR DESCRIPTION
This was uncovered by @cbrown -- I had assumed that the existing UTM
column was getting populated by the GTFS import process, but it's not,
so it's necessary to copy over geometry data from the WGS 84 column into
the newly-transformed UTM zone column.

This adds a second step to the import to do the copying.
