### PR TITLE
Set config object foreign keys to null on delete

### DIFF
--- a/python/django/transit_indicators/migrations/0011_auto_20140806_1413.py
+++ b/python/django/transit_indicators/migrations/0011_auto_20140806_1413.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transit_indicators', '0010_indicator'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='otiindicatorsconfig',
+            name='city_boundary',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, to='datasources.Boundary', null=True),
+        ),
+        migrations.AlterField(
+            model_name='otiindicatorsconfig',
+            name='region_boundary',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, to='datasources.Boundary', null=True),
+        ),
+    ]

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -31,12 +31,16 @@ class OTIIndicatorsConfig(models.Model):
     # relationship, which prevents a conflict because otherwise each Boundary
     # would have two fields named 'otiindicatorsconfig_set'. If we wanted, we
     # could name them something else to preserve both reverse relationships.
+    # Set key to null when referenced boundary is deleted.
     # Boundary denoting the city -- used for calculating percentage of system
     # falling inside city limits
-    city_boundary = models.ForeignKey(Boundary, blank=True, null=True, related_name='+')
+    city_boundary = models.ForeignKey(Boundary, blank=True, null=True,
+                                      on_delete=models.SET_NULL, related_name='+')
 
     # Boundary denoting the region
-    region_boundary = models.ForeignKey(Boundary, blank=True, null=True, related_name='+')
+    # Set key to null when referenced boundary is deleted.
+    region_boundary = models.ForeignKey(Boundary, blank=True, null=True,
+                                        on_delete=models.SET_NULL, related_name='+')
 
 
 class OTIDemographicConfig(models.Model):


### PR DESCRIPTION
The django default of on delete cascade deleted our
single config object every time a city/region boundary
was deleted.
