### PR TITLE
Fix windshaft install on fresh vagrant boxes

### DIFF
--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -447,7 +447,8 @@ if [ "$INSTALL_TYPE" != "travis" ]; then
     pushd $WINDSHAFT_ROOT
         echo "$windshaft_conf" > settings.json
         ## Run as non-sudo user so npm installs libs as not sudo
-        sudo -u "$WEB_USER" npm install  # Travis installs npm stuff in its own setup
+        # Travis installs npm stuff in its own setup
+        sudo -iu "$WEB_USER" bash -c "cd $WINDSHAFT_ROOT && npm install"
     popd
 
     windshaft_upstart="


### PR DESCRIPTION
Provisioning a fresh vagrant box from scratch was failing at the
windshaft stage. Running npm install manually resolved the problem, so
this simulates the login process when running the windshaft install from
the provision script. I was able to successfully provision a fresh
vagrant box with this change.
