### PR TITLE
Remember last selected indicator.

### DIFF
--- a/js/angular/app/scripts/modules/map/map-partial.html
+++ b/js/angular/app/scripts/modules/map/map-partial.html
@@ -5,7 +5,7 @@
     <div class="btn-group" dropdown is-open="indicator_dropdown_open">
       <button type="button" class="btn btn-primary dropdown-toggle" ng-disabled="disabled">
       <!-- TODO: Display actual indicator name here -->
-        Indicator: {{ indicator.type }}<span class="caret"></span>
+        Indicator: {{ indicator.type }} <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
         <li><a ng-click="setIndicator('num_stops')">Num Stops Per Route</a></li>


### PR DESCRIPTION
Fixes TODO by using session cookie to persist last indicator selection through page refresh.
