### PR TITLE
Add post for each indicator type

### DIFF
--- a/geotrellis/src/main/scala/DjangoAdapter.scala
+++ b/geotrellis/src/main/scala/DjangoAdapter.scala
@@ -89,10 +89,10 @@ object DjangoAdapter {
     val pipeline: HttpRequest => Future[HttpResponse] = sendReceive
 
     // Sends a POST request to the indicators endpoint
-    def postIndicator(token: String, indicator: Indicator) = {
+    def postIndicators(token: String, indicators: List[Indicator]) = {
       import JsonImplicits._
 
-      val post = Post(INDICATOR_URI, indicator) ~> addHeader("Authorization", s"Token $token")
+      val post = Post(INDICATOR_URI, indicators) ~> addHeader("Authorization", s"Token $token")
       pipeline(post).map(_.entity.asString) onComplete {
         case Success(response) => println(response)
         case Failure(error) => println("An error has occured: " + error.getMessage)

--- a/geotrellis/src/main/scala/IndicatorsCalculator.scala
+++ b/geotrellis/src/main/scala/IndicatorsCalculator.scala
@@ -29,6 +29,6 @@ class IndicatorsCalculator(val data: GtfsData, val params: CalcParams) {
   // Ask each indicator calculator to store its results.
   // This will eventually be queued and processed in the background.
   def storeIndicators = {
-    calculators.foreach { calc => calc.storeIndicator }
+    for (calc <- calculators) calc.storeIndicators
   }
 }


### PR DESCRIPTION
This adds support for batching the posts of indicator
results to the django API endpoint. Each indicator now
only makes a single post to the API endpoint instead of
making a single post for every single indicator.
