### PR TITLE
Revert to upstream angular-leaflet-directive plugin

### DIFF
--- a/js/angular/app/index.html
+++ b/js/angular/app/index.html
@@ -16,8 +16,8 @@
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
     <!-- build:css styles/vendor.css -->
     <!-- bower:css -->
-    <link rel="stylesheet" href="bower_components/leaflet/dist/leaflet.css" />
     <link rel="stylesheet" href="bower_components/nvd3/src/nv.d3.css" />
+    <link rel="stylesheet" href="bower_components/leaflet/dist/leaflet.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css({.tmp,app}) styles/main.css -->
@@ -64,15 +64,15 @@
     <script src="bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/modal.js"></script>
     <script src="bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/tooltip.js"></script>
     <script src="bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/popover.js"></script>
-    <script src="bower_components/leaflet/dist/leaflet.js"></script>
-    <script src="bower_components/leaflet/dist/leaflet-src.js"></script>
-    <script src="bower_components/angular-leaflet-directive/dist/angular-leaflet-directive.js"></script>
-    <script src="bower_components/leaflet-utfgrid/dist/leaflet.utfgrid.js"></script>
-    <script src="bower_components/leaflet-label/dist/leaflet.label.js"></script>
-    <script src="bower_components/leaflet-tilelayer-geojson/TileLayer.GeoJSON.js"></script>
     <script src="bower_components/d3/d3.js"></script>
     <script src="bower_components/nvd3/nv.d3.js"></script>
     <script src="bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js"></script>
+    <script src="bower_components/leaflet/dist/leaflet.js"></script>
+    <script src="bower_components/leaflet/dist/leaflet-src.js"></script>
+    <script src="bower_components/leaflet-utfgrid/dist/leaflet.utfgrid.js"></script>
+    <script src="bower_components/leaflet-label/dist/leaflet.label.js"></script>
+    <script src="bower_components/leaflet-tilelayer-geojson/TileLayer.GeoJSON.js"></script>
+    <script src="bower_components/angular-leaflet-directive/dist/angular-leaflet-directive.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/js/angular/bower.json
+++ b/js/angular/bower.json
@@ -31,11 +31,11 @@
     "angular-ui-utils": "0.1.1",
     "underscore": "1.6.0",
     "bootstrap-sass-official": "3.1.1+1",
-    "angular-leaflet-directive": "azavea/angular-leaflet-directive#master",
     "leaflet-utfgrid": "danzel/Leaflet.utfgrid",
     "leaflet-label": "Leaflet/Leaflet.label",
     "leaflet-tilelayer-geojson": "glenrobertson/leaflet-tilelayer-geojson",
-    "angularjs-nvd3-directives": "~0.0.7"
+    "angularjs-nvd3-directives": "~0.0.7",
+    "angular-leaflet-directive": "~0.7.8"
   },
   "devDependencies": {
     "angular-mocks": "1.2.15",


### PR DESCRIPTION
Requires > v0.7.8 of the angular-leaflet-directive for
utfgrid support.

The changes we made to our internal fork were merged to
upstream and the version was updated.

Those with an existing install may need to manually run:

```
cd js/angular
bower update angular-leaflet-directive
```

in order to pull in the new dependency.
