### PR TITLE
Fix units and aggregation of length calculator

### DIFF
--- a/geotrellis/src/main/scala/indicators/Length.scala
+++ b/geotrellis/src/main/scala/indicators/Length.scala
@@ -18,7 +18,7 @@ class Length(val gtfsData: GtfsData, val calcParams: CalcParams, val db: Databas
             gtfsData.shapesById.get(shapeID) match {
               case None => max
               case Some(tripShape) => {
-                math.max(max, tripShape.line.length)
+                math.max(max, tripShape.line.length / 1000)
               }
             }
           }
@@ -28,9 +28,9 @@ class Length(val gtfsData: GtfsData, val calcParams: CalcParams, val db: Databas
   }
 
   def calcByMode(period: SamplePeriod): Map[Int, Double] = {
-    // get the transit length per route, group by route type, and average all the lengths
+    // get the transit length per route, group by route type, and sum all the lengths
     calcByRoute(period).toList
       .groupBy(kv => routeByID(kv._1).route_type.id)
-      .mapValues(v => v.map(_._2).sum / v.size)
+      .mapValues(v => v.map(_._2).sum)
   }
 }

--- a/geotrellis/src/test/scala/IndicatorsCalculatorSpec.scala
+++ b/geotrellis/src/test/scala/IndicatorsCalculatorSpec.scala
@@ -151,47 +151,47 @@ class IndicatorsCalculatorSpec extends FlatSpec with PostgresSpec with Matchers 
 
   it should "calculate length by mode for SEPTA" in {
     val lengthByMode = septaRailCalc.calculatorsByName("length").calcByMode(period)
-    lengthByMode(2) should be (50491.14587 plusOrMinus 1e-5)
+    lengthByMode(2) should be (656.38489 plusOrMinus 1e-5)
   }
 
   it should "calculate overall length by mode for SEPTA" in {
     val lengthByMode = septaRailCalc.calculatorsByName("length").calcOverallByMode
-    lengthByMode(2) should be (47523.43482 plusOrMinus 1e-5)
+    lengthByMode(2) should be (589.67491 plusOrMinus 1e-5)
   }
 
   it should "calculate length by route for SEPTA" in {
     val lengthByRoute = septaRailCalc.calculatorsByName("length").calcByRoute(period)
-    lengthByRoute("AIR") should be ( 21869.07041 plusOrMinus 1e-5)
-    lengthByRoute("CHE") should be ( 22475.20005 plusOrMinus 1e-5)
-    lengthByRoute("CHW") should be ( 23381.68619 plusOrMinus 1e-5)
-    lengthByRoute("CYN") should be ( 10088.48478 plusOrMinus 1e-5)
-    lengthByRoute("FOX") should be ( 14583.65208 plusOrMinus 1e-5)
-    lengthByRoute("LAN") should be ( 59691.38456 plusOrMinus 1e-5)
-    lengthByRoute("MED") should be ( 58339.78184 plusOrMinus 1e-5)
-    lengthByRoute("NOR") should be ( 34500.16020 plusOrMinus 1e-5)
-    lengthByRoute("PAO") should be ( 61050.67204 plusOrMinus 1e-5)
-    lengthByRoute("TRE") should be (117481.24562 plusOrMinus 1e-5)
-    lengthByRoute("WAR") should be ( 45306.01143 plusOrMinus 1e-5)
-    lengthByRoute("WIL") should be (130047.07158 plusOrMinus 1e-5)
-    lengthByRoute("WTR") should be ( 57570.47550 plusOrMinus 1e-5)
+    lengthByRoute("AIR") should be ( 21.86907 plusOrMinus 1e-5)
+    lengthByRoute("CHE") should be ( 22.47520 plusOrMinus 1e-5)
+    lengthByRoute("CHW") should be ( 23.38168 plusOrMinus 1e-5)
+    lengthByRoute("CYN") should be ( 10.08848 plusOrMinus 1e-5)
+    lengthByRoute("FOX") should be ( 14.58365 plusOrMinus 1e-5)
+    lengthByRoute("LAN") should be ( 59.69138 plusOrMinus 1e-5)
+    lengthByRoute("MED") should be ( 58.33978 plusOrMinus 1e-5)
+    lengthByRoute("NOR") should be ( 34.50016 plusOrMinus 1e-5)
+    lengthByRoute("PAO") should be ( 61.05067 plusOrMinus 1e-5)
+    lengthByRoute("TRE") should be (117.48124 plusOrMinus 1e-5)
+    lengthByRoute("WAR") should be ( 45.30601 plusOrMinus 1e-5)
+    lengthByRoute("WIL") should be (130.04707 plusOrMinus 1e-5)
+    lengthByRoute("WTR") should be ( 57.57047 plusOrMinus 1e-5)
   }
 
   it should "calculate overall length by route for SEPTA" in {
     val lengthByRoute = septaRailCalc.calculatorsByName("length").calcOverallByRoute
-    lengthByRoute("AIR") should be ( 21868.81730 plusOrMinus 1e-5)
-    lengthByRoute("CHE") should be ( 18584.54364 plusOrMinus 1e-5)
-    lengthByRoute("CHW") should be ( 19110.63894 plusOrMinus 1e-5)
-    lengthByRoute("CYN") should be (  4053.40906 plusOrMinus 1e-5)
-    lengthByRoute("FOX") should be ( 14583.48329 plusOrMinus 1e-5)
-    lengthByRoute("GLN") should be (     0.00000 plusOrMinus 1e-5)
-    lengthByRoute("LAN") should be ( 53766.02689 plusOrMinus 1e-5)
-    lengthByRoute("MED") should be ( 35065.42606 plusOrMinus 1e-5)
-    lengthByRoute("NOR") should be ( 34499.76089 plusOrMinus 1e-5)
-    lengthByRoute("PAO") should be ( 59629.12721 plusOrMinus 1e-5)
-    lengthByRoute("TRE") should be (103943.50170 plusOrMinus 1e-5)
-    lengthByRoute("WAR") should be ( 41077.04152 plusOrMinus 1e-5)
-    lengthByRoute("WIL") should be (130045.56640 plusOrMinus 1e-5)
-    lengthByRoute("WTR") should be ( 53447.57621 plusOrMinus 1e-5)
+    lengthByRoute("AIR") should be ( 21.86881 plusOrMinus 1e-5)
+    lengthByRoute("CHE") should be ( 18.58454 plusOrMinus 1e-5)
+    lengthByRoute("CHW") should be ( 19.11063 plusOrMinus 1e-5)
+    lengthByRoute("CYN") should be (  4.05340 plusOrMinus 1e-5)
+    lengthByRoute("FOX") should be ( 14.58348 plusOrMinus 1e-5)
+    lengthByRoute("GLN") should be (  0.00000 plusOrMinus 1e-5)
+    lengthByRoute("LAN") should be ( 53.76602 plusOrMinus 1e-5)
+    lengthByRoute("MED") should be ( 35.06542 plusOrMinus 1e-5)
+    lengthByRoute("NOR") should be ( 34.49976 plusOrMinus 1e-5)
+    lengthByRoute("PAO") should be ( 59.62912 plusOrMinus 1e-5)
+    lengthByRoute("TRE") should be (103.94350 plusOrMinus 1e-5)
+    lengthByRoute("WAR") should be ( 41.07704 plusOrMinus 1e-5)
+    lengthByRoute("WIL") should be (130.04556 plusOrMinus 1e-5)
+    lengthByRoute("WTR") should be ( 53.44757 plusOrMinus 1e-5)
   }
 
   it should "calculate time_traveled_stops by mode for SEPTA" in {
@@ -300,12 +300,12 @@ class IndicatorsCalculatorSpec extends FlatSpec with PostgresSpec with Matchers 
       case Some(shapeLine) => shapeLine.points.length should be (805)
     }
   }
-  
+
   it should "calcuate overall distance_between_stops by route for SEPTA" in {
     val dbsByMode = septaRailCalc.calculatorsByName("distance_stops").calcOverallByMode
     dbsByMode(2) should be (2.37463 plusOrMinus 1e-5)
   }
-  
+
   it should "calcuate distance_between_stops by route for SEPTA" in {
     val dbsByRoute = septaRailCalc.calculatorsByName("distance_stops").calcOverallByRoute
     dbsByRoute("PAO") should be (1.87185 plusOrMinus 1e-5)


### PR DESCRIPTION
The units were in meters when kilometers were desired.
Also, the the mode aggregation was using an average when
it should have been using a sum.

Note: these number are now in the ballpark with reality,
but still don't look perfect. SEPTA rail is showing 551
kilometers, where it should be somewhere around 450.
Adding an issue to address this.
