### PR TITLE
Replace lazy with eager map method

### DIFF
--- a/geotrellis/src/main/scala/indicators/DistanceStops.scala
+++ b/geotrellis/src/main/scala/indicators/DistanceStops.scala
@@ -48,6 +48,6 @@ class DistanceStops(val gtfsData: GtfsData, val calcParams: CalcParams, val db: 
     // and average all the distances
     calcByRoute(period).toList
       .groupBy(kv => routeByID(kv._1).route_type.id)
-      .mapValues(v => v.map(_._2).sum / v.size)
+      .map { case (key, value) => key -> value.map(_._2).sum / value.size }
   }
 }

--- a/geotrellis/src/main/scala/indicators/Length.scala
+++ b/geotrellis/src/main/scala/indicators/Length.scala
@@ -31,6 +31,6 @@ class Length(val gtfsData: GtfsData, val calcParams: CalcParams, val db: Databas
     // get the transit length per route, group by route type, and sum all the lengths
     calcByRoute(period).toList
       .groupBy(kv => routeByID(kv._1).route_type.id)
-      .mapValues(v => v.map(_._2).sum)
+      .map { case (key, value) => key -> value.map(_._2).sum }
   }
 }

--- a/geotrellis/src/main/scala/indicators/NumRoutes.scala
+++ b/geotrellis/src/main/scala/indicators/NumRoutes.scala
@@ -21,6 +21,6 @@ class NumRoutes(val gtfsData: GtfsData, val calcParams: CalcParams, val db: Data
     // get all routes, group by route type, and count the size of each group
     routesInPeriod(period)
       .groupBy(_.route_type.id)
-      .mapValues(_.size)
+      .map { case (key, value) => key -> value.size.toDouble }
   }
 }

--- a/geotrellis/src/main/scala/indicators/NumStops.scala
+++ b/geotrellis/src/main/scala/indicators/NumStops.scala
@@ -27,10 +27,12 @@ class NumStops(val gtfsData: GtfsData, val calcParams: CalcParams, val db: Datab
      // get all routes, group by route type, and find the unique stop ids per route (via trips)
     routesInPeriod(period)
       .groupBy(_.route_type.id)
-      .mapValues(_.map(_.id)
-        .map(routeID => tripsInPeriod(period, routeByID(routeID))
+      .map { case (key, value) => key -> value.map(_.id)
+        .map(
+          routeID => tripsInPeriod(period, routeByID(routeID))
           .map(stopsInPeriod(period, _).map(_.stop_id))
           .flatten
-      ).flatten.distinct.length)
+        ).flatten.distinct.length.toDouble
+      }
   }
 }

--- a/geotrellis/src/main/scala/indicators/TimeTraveledStops.scala
+++ b/geotrellis/src/main/scala/indicators/TimeTraveledStops.scala
@@ -20,11 +20,11 @@ class TimeTraveledStops(val gtfsData: GtfsData, val calcParams: CalcParams, val 
   def calcByMode(period: SamplePeriod): Map[Int, Double] = {
     durationsBetweenStopsPerRoute(period).toList
       .groupBy(kv => routeByID(kv._1).route_type.id)
-      .mapValues(routesToDurations => {
+      .map { case (key, routesToDurations) => key -> {
         val durations = routesToDurations.map(_._2).flatten
-        durations.sum / durations.size
+        durations.sum / durations.size.toDouble
       }
-    )
+    }
   }
 
 


### PR DESCRIPTION
The more verbose map { case (key, value) => key -> val.mappedMethod } is eager. 
A discussion of the topic: https://issues.scala-lang.org/browse/SI-4776
Evidently, they're planning to rename mapValues: http://www.scala-lang.org/news/roadmap-next
