### PR TITLE
Added Logging

### DIFF
--- a/geotrellis/build.sbt
+++ b/geotrellis/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies ++= Seq(
   "com.azavea" %% "gtfs-parser" % "0.1-SNAPSHOT",
   "com.github.nscala-time" %% "nscala-time" % "1.4.0",
   "org.scalatest" %% "scalatest" % "2.1.5" % "test",
-  "org.slf4j" % "slf4j-nop" % "1.6.4",
-  "org.scala-lang" % "scala-compiler" % "2.10.3"
+
+  "ch.qos.logback" % "logback-classic" % "1.1.1",
+  "org.clapper" %% "grizzled-slf4j" % "1.0.2"
 )

--- a/geotrellis/src/main/scala/GeoTrellisService.scala
+++ b/geotrellis/src/main/scala/GeoTrellisService.scala
@@ -33,6 +33,8 @@ import DefaultJsonProtocol._
 import org.joda.time.format.ISODateTimeFormat
 import com.typesafe.config.{ConfigFactory, Config}
 
+import grizzled.slf4j.Logging
+
 trait GtfsDatabase {
   val db: DatabaseDef
 }
@@ -63,7 +65,7 @@ trait LoadedGtfsData { self: GtfsDatabase =>
   }
 }
 
-trait GeoTrellisServiceRoute extends HttpService with GeoTrellisService { self: GtfsDatabase =>
+trait GeoTrellisServiceRoute extends HttpService with GeoTrellisService with Logging { self: GtfsDatabase =>
   // For performing extent queries
   case class Extent(xmin: Double, xmax: Double, ymin: Double, ymax: Double)
   implicit val getExtentResult = GetResult(r => Extent(r.<<, r.<<, r.<<, r.<<))
@@ -116,6 +118,7 @@ trait GeoTrellisServiceRoute extends HttpService with GeoTrellisService { self: 
           entity(as[CalcParams]) { calcParams =>
             complete {
               try {
+                debug(s"gt/indicators called with $calcParams")
                 calculateIndicators(calcParams)
 
                 // return a 201 created


### PR DESCRIPTION
Added logback as a logging implementation for SLF4J with Scala wrapper provided by Grizzled.
http://software.clapper.org/grizzled-slf4j/

In most cases it should be sufficient to extend `grizzled.slf4j.Logging` and use the `error`, `debug`,`info` methods.

This will require the following Pull Request ion GT to be merged to function:
https://github.com/geotrellis/geotrellis/pull/883
