### PR TITLE
Fix Python tests for moved city_name.

### DIFF
--- a/python/django/transit_indicators/i18n/es/LC_MESSAGES/django.po
+++ b/python/django/transit_indicators/i18n/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-09-17 12:49+0000\n"
+"POT-Creation-Date: 2014-09-17 16:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -582,166 +582,166 @@ msgstr ""
 msgid "Completed indicator calculation"
 msgstr ""
 
-#: transit_indicators/models.py:252
+#: transit_indicators/models.py:258
 msgid "Route"
 msgstr ""
 
-#: transit_indicators/models.py:253
+#: transit_indicators/models.py:259
 msgid "Mode"
 msgstr ""
 
-#: transit_indicators/models.py:254
+#: transit_indicators/models.py:260
 msgid "System"
 msgstr ""
 
-#: transit_indicators/models.py:286
+#: transit_indicators/models.py:292
 msgid "avg deviation from scheduled dwell time"
 msgstr ""
 
-#: transit_indicators/models.py:287
+#: transit_indicators/models.py:293
 msgid "avg deviation from scheduled frequency"
 msgstr ""
 
-#: transit_indicators/models.py:288
+#: transit_indicators/models.py:294
 msgid "avg deviation from scheduled time"
 msgstr ""
 
-#: transit_indicators/models.py:289
+#: transit_indicators/models.py:295
 msgid "stops per hr/pop within 500m"
 msgstr ""
 
-#: transit_indicators/models.py:290
+#: transit_indicators/models.py:296
 msgid "hrs"
 msgstr ""
 
-#: transit_indicators/models.py:291
+#: transit_indicators/models.py:297
 msgid "km"
 msgstr ""
 
-#: transit_indicators/models.py:292
+#: transit_indicators/models.py:298
 msgid "km/km²"
 msgstr ""
 
-#: transit_indicators/models.py:293
+#: transit_indicators/models.py:299
 msgid "low-income population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:294
+#: transit_indicators/models.py:300
 msgid "min"
 msgstr ""
 
-#: transit_indicators/models.py:295
+#: transit_indicators/models.py:301
 msgid "population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:296
+#: transit_indicators/models.py:302
 msgid "stops/500m radius"
 msgstr ""
 
-#: transit_indicators/models.py:297
+#: transit_indicators/models.py:303
 msgid "stops/route length, in km"
 msgstr ""
 
-#: transit_indicators/models.py:321
+#: transit_indicators/models.py:327
 msgid "Access index"
 msgstr ""
 
-#: transit_indicators/models.py:322
+#: transit_indicators/models.py:328
 msgid "Affordability"
 msgstr ""
 
-#: transit_indicators/models.py:323
+#: transit_indicators/models.py:329
 msgid "Average Service Frequency"
 msgstr ""
 
-#: transit_indicators/models.py:324
+#: transit_indicators/models.py:330
 msgid "System coverage"
 msgstr ""
 
-#: transit_indicators/models.py:325
+#: transit_indicators/models.py:331
 msgid "Coverage of transit stops"
 msgstr ""
 
-#: transit_indicators/models.py:326
+#: transit_indicators/models.py:332
 msgid "Distance between stops"
 msgstr ""
 
-#: transit_indicators/models.py:327
+#: transit_indicators/models.py:333
 msgid "Dwell Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:328
+#: transit_indicators/models.py:334
 msgid "Weekly number of hours of service"
 msgstr ""
 
-#: transit_indicators/models.py:329
+#: transit_indicators/models.py:335
 msgid "Job accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:330
+#: transit_indicators/models.py:336
 msgid "Transit system length"
 msgstr ""
 
-#: transit_indicators/models.py:331
+#: transit_indicators/models.py:337
 msgid "Ratio of transit lines length over road length"
 msgstr ""
 
-#: transit_indicators/models.py:332
+#: transit_indicators/models.py:338
 msgid "Transit line network density"
 msgstr ""
 
-#: transit_indicators/models.py:333
+#: transit_indicators/models.py:339
 msgid "Number of modes"
 msgstr ""
 
-#: transit_indicators/models.py:334
+#: transit_indicators/models.py:340
 msgid "Number of routes"
 msgstr ""
 
-#: transit_indicators/models.py:335
+#: transit_indicators/models.py:341
 msgid "Number of stops"
 msgstr ""
 
-#: transit_indicators/models.py:336
+#: transit_indicators/models.py:342
 msgid "Number of route types"
 msgstr ""
 
-#: transit_indicators/models.py:337
+#: transit_indicators/models.py:343
 msgid "On-Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:338
+#: transit_indicators/models.py:344
 msgid "Regularity of Headways"
 msgstr ""
 
-#: transit_indicators/models.py:339
+#: transit_indicators/models.py:345
 msgid "Service frequency weighted by served population"
 msgstr ""
 
-#: transit_indicators/models.py:340
+#: transit_indicators/models.py:346
 msgid "Ratio of number of stops to route-length"
 msgstr ""
 
-#: transit_indicators/models.py:341
+#: transit_indicators/models.py:347
 msgid "Ratio of the Transit-Pattern Operating Suburban Lines"
 msgstr ""
 
-#: transit_indicators/models.py:342
+#: transit_indicators/models.py:348
 msgid "System accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:343
+#: transit_indicators/models.py:349
 msgid "System accessibility - low-income"
 msgstr ""
 
-#: transit_indicators/models.py:344
+#: transit_indicators/models.py:350
 msgid "Time traveled between stops"
 msgstr ""
 
-#: transit_indicators/models.py:345
+#: transit_indicators/models.py:351
 msgid "Travel Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:346
+#: transit_indicators/models.py:352
 msgid "Weekday / weekend frequency"
 msgstr ""

--- a/python/django/transit_indicators/i18n/vi/LC_MESSAGES/django.po
+++ b/python/django/transit_indicators/i18n/vi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-09-17 12:49+0000\n"
+"POT-Creation-Date: 2014-09-17 16:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -582,166 +582,166 @@ msgstr ""
 msgid "Completed indicator calculation"
 msgstr ""
 
-#: transit_indicators/models.py:252
+#: transit_indicators/models.py:258
 msgid "Route"
 msgstr ""
 
-#: transit_indicators/models.py:253
+#: transit_indicators/models.py:259
 msgid "Mode"
 msgstr ""
 
-#: transit_indicators/models.py:254
+#: transit_indicators/models.py:260
 msgid "System"
 msgstr ""
 
-#: transit_indicators/models.py:286
+#: transit_indicators/models.py:292
 msgid "avg deviation from scheduled dwell time"
 msgstr ""
 
-#: transit_indicators/models.py:287
+#: transit_indicators/models.py:293
 msgid "avg deviation from scheduled frequency"
 msgstr ""
 
-#: transit_indicators/models.py:288
+#: transit_indicators/models.py:294
 msgid "avg deviation from scheduled time"
 msgstr ""
 
-#: transit_indicators/models.py:289
+#: transit_indicators/models.py:295
 msgid "stops per hr/pop within 500m"
 msgstr ""
 
-#: transit_indicators/models.py:290
+#: transit_indicators/models.py:296
 msgid "hrs"
 msgstr ""
 
-#: transit_indicators/models.py:291
+#: transit_indicators/models.py:297
 msgid "km"
 msgstr ""
 
-#: transit_indicators/models.py:292
+#: transit_indicators/models.py:298
 msgid "km/km²"
 msgstr ""
 
-#: transit_indicators/models.py:293
+#: transit_indicators/models.py:299
 msgid "low-income population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:294
+#: transit_indicators/models.py:300
 msgid "min"
 msgstr ""
 
-#: transit_indicators/models.py:295
+#: transit_indicators/models.py:301
 msgid "population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:296
+#: transit_indicators/models.py:302
 msgid "stops/500m radius"
 msgstr ""
 
-#: transit_indicators/models.py:297
+#: transit_indicators/models.py:303
 msgid "stops/route length, in km"
 msgstr ""
 
-#: transit_indicators/models.py:321
+#: transit_indicators/models.py:327
 msgid "Access index"
 msgstr ""
 
-#: transit_indicators/models.py:322
+#: transit_indicators/models.py:328
 msgid "Affordability"
 msgstr ""
 
-#: transit_indicators/models.py:323
+#: transit_indicators/models.py:329
 msgid "Average Service Frequency"
 msgstr ""
 
-#: transit_indicators/models.py:324
+#: transit_indicators/models.py:330
 msgid "System coverage"
 msgstr ""
 
-#: transit_indicators/models.py:325
+#: transit_indicators/models.py:331
 msgid "Coverage of transit stops"
 msgstr ""
 
-#: transit_indicators/models.py:326
+#: transit_indicators/models.py:332
 msgid "Distance between stops"
 msgstr ""
 
-#: transit_indicators/models.py:327
+#: transit_indicators/models.py:333
 msgid "Dwell Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:328
+#: transit_indicators/models.py:334
 msgid "Weekly number of hours of service"
 msgstr ""
 
-#: transit_indicators/models.py:329
+#: transit_indicators/models.py:335
 msgid "Job accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:330
+#: transit_indicators/models.py:336
 msgid "Transit system length"
 msgstr ""
 
-#: transit_indicators/models.py:331
+#: transit_indicators/models.py:337
 msgid "Ratio of transit lines length over road length"
 msgstr ""
 
-#: transit_indicators/models.py:332
+#: transit_indicators/models.py:338
 msgid "Transit line network density"
 msgstr ""
 
-#: transit_indicators/models.py:333
+#: transit_indicators/models.py:339
 msgid "Number of modes"
 msgstr ""
 
-#: transit_indicators/models.py:334
+#: transit_indicators/models.py:340
 msgid "Number of routes"
 msgstr ""
 
-#: transit_indicators/models.py:335
+#: transit_indicators/models.py:341
 msgid "Number of stops"
 msgstr ""
 
-#: transit_indicators/models.py:336
+#: transit_indicators/models.py:342
 msgid "Number of route types"
 msgstr ""
 
-#: transit_indicators/models.py:337
+#: transit_indicators/models.py:343
 msgid "On-Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:338
+#: transit_indicators/models.py:344
 msgid "Regularity of Headways"
 msgstr ""
 
-#: transit_indicators/models.py:339
+#: transit_indicators/models.py:345
 msgid "Service frequency weighted by served population"
 msgstr ""
 
-#: transit_indicators/models.py:340
+#: transit_indicators/models.py:346
 msgid "Ratio of number of stops to route-length"
 msgstr ""
 
-#: transit_indicators/models.py:341
+#: transit_indicators/models.py:347
 msgid "Ratio of the Transit-Pattern Operating Suburban Lines"
 msgstr ""
 
-#: transit_indicators/models.py:342
+#: transit_indicators/models.py:348
 msgid "System accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:343
+#: transit_indicators/models.py:349
 msgid "System accessibility - low-income"
 msgstr ""
 
-#: transit_indicators/models.py:344
+#: transit_indicators/models.py:350
 msgid "Time traveled between stops"
 msgstr ""
 
-#: transit_indicators/models.py:345
+#: transit_indicators/models.py:351
 msgid "Travel Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:346
+#: transit_indicators/models.py:352
 msgid "Weekday / weekend frequency"
 msgstr ""

--- a/python/django/transit_indicators/i18n/zh/LC_MESSAGES/django.po
+++ b/python/django/transit_indicators/i18n/zh/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-09-17 12:49+0000\n"
+"POT-Creation-Date: 2014-09-17 16:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -581,166 +581,166 @@ msgstr ""
 msgid "Completed indicator calculation"
 msgstr ""
 
-#: transit_indicators/models.py:252
+#: transit_indicators/models.py:258
 msgid "Route"
 msgstr ""
 
-#: transit_indicators/models.py:253
+#: transit_indicators/models.py:259
 msgid "Mode"
 msgstr ""
 
-#: transit_indicators/models.py:254
+#: transit_indicators/models.py:260
 msgid "System"
 msgstr ""
 
-#: transit_indicators/models.py:286
+#: transit_indicators/models.py:292
 msgid "avg deviation from scheduled dwell time"
 msgstr ""
 
-#: transit_indicators/models.py:287
+#: transit_indicators/models.py:293
 msgid "avg deviation from scheduled frequency"
 msgstr ""
 
-#: transit_indicators/models.py:288
+#: transit_indicators/models.py:294
 msgid "avg deviation from scheduled time"
 msgstr ""
 
-#: transit_indicators/models.py:289
+#: transit_indicators/models.py:295
 msgid "stops per hr/pop within 500m"
 msgstr ""
 
-#: transit_indicators/models.py:290
+#: transit_indicators/models.py:296
 msgid "hrs"
 msgstr ""
 
-#: transit_indicators/models.py:291
+#: transit_indicators/models.py:297
 msgid "km"
 msgstr ""
 
-#: transit_indicators/models.py:292
+#: transit_indicators/models.py:298
 msgid "km/km²"
 msgstr ""
 
-#: transit_indicators/models.py:293
+#: transit_indicators/models.py:299
 msgid "low-income population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:294
+#: transit_indicators/models.py:300
 msgid "min"
 msgstr ""
 
-#: transit_indicators/models.py:295
+#: transit_indicators/models.py:301
 msgid "population within 500m of a stop"
 msgstr ""
 
-#: transit_indicators/models.py:296
+#: transit_indicators/models.py:302
 msgid "stops/500m radius"
 msgstr ""
 
-#: transit_indicators/models.py:297
+#: transit_indicators/models.py:303
 msgid "stops/route length, in km"
 msgstr ""
 
-#: transit_indicators/models.py:321
+#: transit_indicators/models.py:327
 msgid "Access index"
 msgstr ""
 
-#: transit_indicators/models.py:322
+#: transit_indicators/models.py:328
 msgid "Affordability"
 msgstr ""
 
-#: transit_indicators/models.py:323
+#: transit_indicators/models.py:329
 msgid "Average Service Frequency"
 msgstr ""
 
-#: transit_indicators/models.py:324
+#: transit_indicators/models.py:330
 msgid "System coverage"
 msgstr ""
 
-#: transit_indicators/models.py:325
+#: transit_indicators/models.py:331
 msgid "Coverage of transit stops"
 msgstr ""
 
-#: transit_indicators/models.py:326
+#: transit_indicators/models.py:332
 msgid "Distance between stops"
 msgstr ""
 
-#: transit_indicators/models.py:327
+#: transit_indicators/models.py:333
 msgid "Dwell Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:328
+#: transit_indicators/models.py:334
 msgid "Weekly number of hours of service"
 msgstr ""
 
-#: transit_indicators/models.py:329
+#: transit_indicators/models.py:335
 msgid "Job accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:330
+#: transit_indicators/models.py:336
 msgid "Transit system length"
 msgstr ""
 
-#: transit_indicators/models.py:331
+#: transit_indicators/models.py:337
 msgid "Ratio of transit lines length over road length"
 msgstr ""
 
-#: transit_indicators/models.py:332
+#: transit_indicators/models.py:338
 msgid "Transit line network density"
 msgstr ""
 
-#: transit_indicators/models.py:333
+#: transit_indicators/models.py:339
 msgid "Number of modes"
 msgstr ""
 
-#: transit_indicators/models.py:334
+#: transit_indicators/models.py:340
 msgid "Number of routes"
 msgstr ""
 
-#: transit_indicators/models.py:335
+#: transit_indicators/models.py:341
 msgid "Number of stops"
 msgstr ""
 
-#: transit_indicators/models.py:336
+#: transit_indicators/models.py:342
 msgid "Number of route types"
 msgstr ""
 
-#: transit_indicators/models.py:337
+#: transit_indicators/models.py:343
 msgid "On-Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:338
+#: transit_indicators/models.py:344
 msgid "Regularity of Headways"
 msgstr ""
 
-#: transit_indicators/models.py:339
+#: transit_indicators/models.py:345
 msgid "Service frequency weighted by served population"
 msgstr ""
 
-#: transit_indicators/models.py:340
+#: transit_indicators/models.py:346
 msgid "Ratio of number of stops to route-length"
 msgstr ""
 
-#: transit_indicators/models.py:341
+#: transit_indicators/models.py:347
 msgid "Ratio of the Transit-Pattern Operating Suburban Lines"
 msgstr ""
 
-#: transit_indicators/models.py:342
+#: transit_indicators/models.py:348
 msgid "System accessibility"
 msgstr ""
 
-#: transit_indicators/models.py:343
+#: transit_indicators/models.py:349
 msgid "System accessibility - low-income"
 msgstr ""
 
-#: transit_indicators/models.py:344
+#: transit_indicators/models.py:350
 msgid "Time traveled between stops"
 msgstr ""
 
-#: transit_indicators/models.py:345
+#: transit_indicators/models.py:351
 msgid "Travel Time Performance"
 msgstr ""
 
-#: transit_indicators/models.py:346
+#: transit_indicators/models.py:352
 msgid "Weekday / weekend frequency"
 msgstr ""

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -199,6 +199,7 @@ class Indicator(models.Model):
         sample_period_cache = {}
         if not city_name:
             response.errors.append('city_name parameter required')
+            response.success = False
             return response
         try:
             # first, invalidate previous indicator calculations uploaded for this city
@@ -213,6 +214,11 @@ class Indicator(models.Model):
             dict_reader.next()
             with transaction.atomic():
                 for row in dict_reader:
+                    # check that the exported city name matches the one the user specified
+                    # (ignore any other cities in the uploaded CSV)
+                    this_city = row.pop('city_name')
+                    if this_city != city_name:
+                        continue
                     sp_type = row.pop('sample_period', None)
                     version = row.pop('version', None)
                     if not import_job.version:

--- a/python/django/transit_indicators/views.py
+++ b/python/django/transit_indicators/views.py
@@ -113,7 +113,7 @@ class IndicatorViewSet(OTIAdminViewSet):
         # Handle as csv upload if form data present
         source_file = request.FILES.get('source_file', None)
         if source_file:
-            city_name = request.DATA.get('city_name', None)
+            city_name = request.DATA.pop('city_name', None)
             load_status = Indicator.load(source_file, city_name, request.user)
             response_status = status.HTTP_200_OK if load_status.success else status.HTTP_400_BAD_REQUEST
             return Response(load_status.__dict__, status=response_status)
@@ -147,7 +147,7 @@ class IndicatorViewSet(OTIAdminViewSet):
         endpoint with no params
 
         """
-        delete_filter_fields = ('city_name')
+        delete_filter_fields = {'city_name': 'version__city_name'}
         filters = []
         for field in request.QUERY_PARAMS:
             if field in delete_filter_fields:
@@ -156,7 +156,7 @@ class IndicatorViewSet(OTIAdminViewSet):
         if filters:
             indicators = Indicator.objects.all();
             for field in filters:
-                indicators = indicators.filter(**{field: request.QUERY_PARAMS[field]})
+                indicators = indicators.filter(**{delete_filter_fields.get(field): request.QUERY_PARAMS.get(field)})
             indicators.delete()
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
This fixes the Django tests broken by moving `city_name` to `IndicatorJob`.

CSV import ignores entries for city other that the user-entered one.
