### PR TITLE
Reduce log-level during testing

### DIFF
--- a/geotrellis/src/test/resources/logback-test.xml
+++ b/geotrellis/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <root level="warn">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Logs were causing tests to fail on Travis CI
due to line limits
