### PR TITLE
Fix missing Indicator uniqueness constraint in migrations

### DIFF
--- a/python/django/transit_indicators/migrations/0014_auto_20140808_1756.py
+++ b/python/django/transit_indicators/migrations/0014_auto_20140808_1756.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='indicator',
-            unique_together=set([(b'sample_period', b'type', b'aggregation', b'route_id', b'route_type', b'city_name', b'version')]),
+            unique_together=set([('sample_period', 'type', 'aggregation', 'route_id', 'route_type', 'city_name', 'version')]),
         ),
     ]

--- a/python/django/transit_indicators/migrations/0025_auto_20140908_2041.py
+++ b/python/django/transit_indicators/migrations/0025_auto_20140908_2041.py
@@ -12,6 +12,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterUniqueTogether(
+            name='indicator',
+            unique_together=None
+        ),
         migrations.AlterField(
             model_name='indicatorjob',
             name='version',
@@ -36,5 +40,9 @@ class Migration(migrations.Migration):
             name='version',
             field=models.ForeignKey(to='transit_indicators.IndicatorJob', to_field=b'version'),
             preserve_default=True,
+        ),
+        migrations.AlterUniqueTogether(
+            name='indicator',
+            unique_together=set([('sample_period', 'type', 'aggregation', 'route_id', 'route_type', 'city_name', 'version')]),
         ),
     ]

--- a/python/django/transit_indicators/migrations/0028_auto_20140916_2133.py
+++ b/python/django/transit_indicators/migrations/0028_auto_20140916_2133.py
@@ -11,8 +11,16 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterUniqueTogether(
+            name='indicator',
+            unique_together=None
+        ),
         migrations.RemoveField(
             model_name='indicator',
             name='city_name',
+        ),
+        migrations.AlterUniqueTogether(
+            name='indicator',
+            unique_together=set([('sample_period', 'type', 'aggregation', 'route_id', 'route_type', 'version')]),
         ),
     ]


### PR DESCRIPTION
Source: potential bug in django 1.7 migrations,
write up of root issue here:
https://code.djangoproject.com/ticket/23505#ticket

Root issue is that when we drop a column in the migration,
postgres automatically drops the uniqueness constraint, which
django doesn't catch. Thus, when we try to perform migrations
on the uniqueness constraint later, it fails because in all
cases django expects a constraint to exist when it does not.

Had to modify existing migrations, will require a

```
DROP DATABASE transit_indicators;
```

and a reprovision afterwards

After reprovisioning, ./manage.py makemigrations should not properly report 'no changes'
