### PR TITLE
Filter indicators display on map

### DIFF
--- a/js/angular/app/scripts/modules/indicators/indicators-controller.js
+++ b/js/angular/app/scripts/modules/indicators/indicators-controller.js
@@ -21,7 +21,13 @@ angular.module('transitIndicators')
     };
 
     OTIIndicatorsService.getIndicatorTypes().then(function (data) {
-        $scope.types = data;
+        // filter indicator types to only show those for map display
+        $scope.types = {};
+        _.each(data, function(obj, key) {
+            if (obj.display_on_map == true) {
+                $scope.types[key] = obj.display_name;
+            }
+        });
     });
     OTIIndicatorsService.getIndicatorAggregationTypes().then(function (data) {
         $scope.aggregations = data;

--- a/js/angular/app/scripts/modules/indicators/map-partial.html
+++ b/js/angular/app/scripts/modules/indicators/map-partial.html
@@ -7,7 +7,9 @@
                     {{ aggregations[indicator.aggregation] }} <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                    <li ng-repeat="(key, value) in aggregations"><a ng-click="selectAggregation(key)"> {{ value }}</a></li>
+                    <li ng-repeat="(key, value) in aggregations">
+                        <a ng-click="selectAggregation(key)"> {{ value }}</a>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -18,7 +20,9 @@
                     {{ types[indicator.type] }} <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                    <li ng-repeat="(key, value) in types"><a ng-click="selectType(key)"> {{ value }}</a></li>
+                    <li ng-repeat="(key, value) in types">
+                        <a ng-click="selectType(key)"> {{ value }}</a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -322,6 +322,20 @@ class Indicator(models.Model):
                             TIME_TRAVELED_STOPS: Units.MINUTES,
                             WEEKDAY_END_FREQ: Units.HOURS
         }
+        
+        # indicators to display on the map
+        INDICATORS_TO_MAP = frozenset([
+                              LENGTH,
+                              NUM_STOPS,
+                              HOURS_SERVICE,
+                              STOPS_ROUTE_LENGTH,
+                              DISTANCE_STOPS,
+                              SERVICE_FREQ_WEIGHTED, # TODO: is this headway between stops?
+                              WEEKDAY_END_FREQ,
+                              ON_TIME_PERF,
+                              REGULARITY_HEADWAYS,
+                              COVERAGE
+        ])
 
         CHOICES = (
             (ACCESS_INDEX, _(u'Access index')),

--- a/python/django/transit_indicators/views.py
+++ b/python/django/transit_indicators/views.py
@@ -181,12 +181,19 @@ class IndicatorVersion(APIView):
 class IndicatorTypes(APIView):
     """ Indicator Types GET endpoint
 
-    Returns a dict where key is the db indicator type key and value is
-    the human readable, translated string description
+    Returns a dict where key is the db indicator type key,
+    display_name is the human readable, translated string description, and
+    display_on_map is boolean indicating whether indicator should be shown on map or not
 
     """
     def get(self, request, *args, **kwargs):
-        response = { key: value for key, value in Indicator.IndicatorTypes.CHOICES }
+        response = {}
+        for key, value in Indicator.IndicatorTypes.CHOICES:
+            if Indicator.IndicatorTypes.INDICATORS_TO_MAP.intersection([key]):
+                show = True
+            else:
+                show = False
+            response[key] = { 'display_name': value, 'display_on_map': show }
         return Response(response, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
Limits indicators in map drop-down to those that have a flag set to show on map.

The indicators to show on map should match those marked for map display in the indicators spreadsheet; @jbranigan may have input on whether these match properly.
