### PR TITLE
Fix colors for "Data / Map" buttons

### DIFF
--- a/js/angular/app/scripts/modules/indicators/indicators-partial.html
+++ b/js/angular/app/scripts/modules/indicators/indicators-partial.html
@@ -2,8 +2,8 @@
     <div bs-affix data-offset-top="0" class="navigationsecondary clearfix">
         <div class="navigationsecondary-left">
             <div class="navigationsecondary-menu filter">
-                <div ui-sref="data" class="button--small" ng-class="{inactive: showingMap}">Data</div>/
-                <div ui-sref="map" class="button--small" ng-class="{inactive: !showingMap}">Map</div>
+                <div ui-sref="data" class="button--small" ng-class="{active: !showingMap}">Data</div>/
+                <div ui-sref="map" class="button--small" ng-class="{active: showingMap}">Map</div>
             </div>
         </div>
         <div class="navigationsecondary-right">

--- a/js/angular/app/styles/modules/_buttons.scss
+++ b/js/angular/app/styles/modules/_buttons.scss
@@ -31,7 +31,8 @@
     }
 
     &.active {
-      color: $primary-color;
+      color: #000;
+      font-weight: bold;
     }
 
     &.inactive {


### PR DESCRIPTION
This commit makes the view use the "active" class instead of
"inactive." The styling for "inactive" is left the same but "active"
is altered to bold and black to be more clear.
