### PR TITLE
Add stacked chart for transit length indicator

### DIFF
--- a/js/angular/app/scripts/modules/indicators/charts/bar-mode-partial.html
+++ b/js/angular/app/scripts/modules/indicators/charts/bar-mode-partial.html
@@ -1,5 +1,5 @@
 <nvd3-discrete-bar-chart
-    data="citydata.mode"
+    data="data.mode"
     id="{{ type }}-{{ $index }}-mode-bar-chart"
     height="170"
     showXAxis="true"
@@ -7,5 +7,5 @@
     showValues="true"
     x="charts.bar.xFunctionMode()"
     y="charts.bar.yFunction()"
-    forcey="[0, {{ charts.bar.forceYFunction(type, 'mode') }}]">
+    forcey="[0, {{ charts.bar.forceYFunction(indicatorData, type, 'mode') }}]">
 </nvd3-discrete-bar-chart>

--- a/js/angular/app/scripts/modules/indicators/charts/pie-mode-partial.html
+++ b/js/angular/app/scripts/modules/indicators/charts/pie-mode-partial.html
@@ -1,5 +1,5 @@
 <nvd3-pie-chart
-    data="citydata.mode[0].values"
+    data="data.mode"
     id="{{ type }}-{{ $index }}-mode-pie-chart"
     height="170"
     margin="{left:0,top:10,bottom:0,right:0}"

--- a/js/angular/app/scripts/modules/indicators/charts/stacked-mode-partial.html
+++ b/js/angular/app/scripts/modules/indicators/charts/stacked-mode-partial.html
@@ -1,0 +1,12 @@
+<nvd3-multi-bar-chart
+    data="data.mode"
+    id="{{ type }}-{{ $index }}-mode-stacked-chart"
+    height="170"
+    showYAxis="true"
+    x="charts.stacked.xFunctionMode()"
+    y="charts.stacked.yFunction()"
+    tooltips="true"
+    stacked="true"
+    tooltipcontent="charts.stacked.tooltipFunction()"
+    forcey="[0, {{ charts.stacked.forceYFunction(indicatorData, type, 'mode') }}]">
+</nvd3-discrete-bar-chart>

--- a/js/angular/app/scripts/modules/indicators/data-controller.js
+++ b/js/angular/app/scripts/modules/indicators/data-controller.js
@@ -6,133 +6,16 @@ angular.module('transitIndicators')
 
     var cache = {};
     $scope.updating = false;
-
-    var defaultTooltipFunction = function () {
-        return function (key, x, y) {
-            return '<h3>' + key + '</h3><p>' + y.formatted_value + '</p>';
-        };
-    };
-
-    $scope.charts = {
-        pie: {
-            xFunctionMode: function () {
-                return function (data) {
-                    return data.route_type;
-                };
-            },
-            xFunctionRoute: function () {
-                return function (data) {
-                    return data.route_id;
-                };
-            },
-            yFunction: function () {
-                return function (data) {
-                    return data.value;
-                };
-            },
-            tooltipFunction: defaultTooltipFunction
-        },
-        bar: {
-            xFunctionMode: function () {
-                return function (data) {
-                    return data.route_type;
-                };
-            },
-            yFunction: function () {
-                return function (data) {
-                    return data.value;
-                };
-            },
-            forceYFunction: function (type, aggregation) {
-                return Math.ceil($scope.indicatorData[type][aggregation].max);
-            }
-        }
-    };
-
-    /**
-     * Transforms the /api/indicators/ response into something that we can use in the graphs/table
-     * source data structure:
-
-[OTIIndicatorService.Indicator]
-
-     * dest data structure:
-
-{
-    "<type>": {
-        "<aggregation>": {
-            max: <number>,
-            min: <number>
-        },
-        "cities": {
-            "<city_name>": {
-                "<aggregation>": [{
-                    key: '<aggregation>',
-                    values: [OTIIndicatorService.Indicator]
-                }]
-            }
-        }
-    }
-}
-
-     * @param source data structure defined above
-     * @return dest data structure defined above
-     */
-    var transformData = function (data, cities) {
-        var transformed = {};
-        _.each(data, function (indicator) {
-            if (!transformed[indicator.type]) {
-                transformed[indicator.type] = {
-                    cities: {}
-                };
-            }
-
-            // Calculate max/min for each indicator type
-            if (!transformed[indicator.type].cities[indicator.city_name]) {
-                var indicatorCities = {};
-                // The cities must be set in this object, even if there is no data for that indicator,
-                //  so that we can loop them in the template. If we loop in the template via
-                //  $scope.cities rather than this object, we lose the 2-way binding and updates
-                //  to the indicatorData object no longer update the view.
-                _.each(cities, function (city) {
-                    indicatorCities[city] = {};
-                });
-                transformed[indicator.type].cities = indicatorCities;
-            }
-
-            // Set the indicator into it's proper location
-            if (!transformed[indicator.type].cities[indicator.city_name][indicator.aggregation]) {
-                transformed[indicator.type].cities[indicator.city_name][indicator.aggregation] = [{
-                    key: indicator.aggregation,
-                    values: []
-                }];
-            }
-            transformed[indicator.type].cities[indicator.city_name][indicator.aggregation][0].values.push(indicator);
-
-            // Calculate min/max values of indicator type/aggregation so that
-            //  we can properly scale the graphs
-            if (!transformed[indicator.type][indicator.aggregation]) {
-                transformed[indicator.type][indicator.aggregation] = {
-                    max: Number.NEGATIVE_INFINITY,
-                    min: Number.POSITIVE_INFINITY
-                };
-            }
-            var minmax = transformed[indicator.type][indicator.aggregation];
-            if (indicator.value > minmax.max) {
-                minmax.max = indicator.value;
-            }
-            if (indicator.value < minmax.min) {
-                minmax.min = indicator.value;
-            }
-        });
-        return transformed;
-    };
+    $scope.indicatorDetailKey = OTIIndicatorsService.getIndicatorDescriptionTranslationKey;
+    $scope.charts = OTIIndicatorsDataService.Charts;
 
     var getIndicatorData = function () {
         $scope.updating = true;
         var period = $scope.sample_period;
         if (period) {
             var params = {
-                sample_period: period
+                sample_period: period,
+                aggregation: 'mode,system'
             };
 
             if (cache && cache[period]) {
@@ -140,7 +23,7 @@ angular.module('transitIndicators')
                 $scope.updating = false;
             } else {
                 OTIIndicatorsService.query('GET', params).then(function (data) {
-                    var indicators = transformData(data, $scope.cities);
+                    var indicators = OTIIndicatorsDataService.transformData(data, $scope.cities);
                     $scope.indicatorData = null;
                     $scope.indicatorData = indicators;
                     cache[period] = indicators;
@@ -159,18 +42,21 @@ angular.module('transitIndicators')
         return display;
     };
 
+    $scope.filterDataForChartType = function (data, type, aggregation) {
+        var chartType = OTIIndicatorsDataService.getChartTypeForIndicator(type);
+        if (chartType === 'nodata') {
+            return data;
+        }
+        return $scope.charts[chartType].filterFunction(data, aggregation);
+    };
+
     $scope.getModePartialForIndicator = function (type) {
-        var config = $scope.indicatorConfig;
-        var chartType = config && config[type] && config[type].mode ? config[type].mode : 'nodata';
+        var chartType = OTIIndicatorsDataService.getChartTypeForIndicator(type);
         var url = '/scripts/modules/indicators/charts/:charttype-mode-partial.html';
         return url.replace(':charttype', chartType);
     };
 
     $scope.indicatorConfig = OTIIndicatorsDataService.IndicatorConfig;
-
-    $scope.getIndicatorDescriptionTranslationKey = function(key) {
-        return 'INDICATOR_DESCRIPTION.' + key;
-    };
 
     $scope.$on(OTIEvents.Indicators.SamplePeriodUpdated, function () {
         getIndicatorData();

--- a/js/angular/app/scripts/modules/indicators/data-partial.html
+++ b/js/angular/app/scripts/modules/indicators/data-partial.html
@@ -19,15 +19,20 @@
     <div class="indicators-row">
         <div class="indicators-cell indicators-label">
             <h3>{{ types[type] }}</h3>
-            <p>{{ getIndicatorDescriptionTranslationKey(type) | translate }}</p>
+            <p>{{ indicatorDetailKey(type) | translate }}</p>
         </div>
+        <!-- store transformed data on local ng-repeat scope via ng-init
+             cannot directly call filterFunction in the nvd3 directive data attribute
+             because that attribute is watched, and calling a function there causes
+             inf watch cycles
+        -->
         <div ng-repeat="(cityname, citydata) in indicator.cities"
-             ng-init="systemData = citydata.system[0].values"
+             ng-init="data = { system: citydata.system[0].values, mode: filterDataForChartType(citydata, type, 'mode') }"
              class="indicators-cell">
             <div ng-if="displayIndicator(type, 'mode')">
                 <ng-include src="getModePartialForIndicator(type)"></ng-include>
             </div>
-            <span ng-if="displayIndicator(type, 'system')">{{ systemData[0].formatted_value || "No Data Available" }}</span>
+            <span ng-if="displayIndicator(type, 'system')">{{ data.system[0].formatted_value || "No Data Available" }}</span>
         </div>
     </div>
 </div>

--- a/js/angular/app/scripts/modules/indicators/data-service.js
+++ b/js/angular/app/scripts/modules/indicators/data-service.js
@@ -7,6 +7,96 @@ angular.module('transitIndicators')
 
     var otiDataService = {};
 
+    /// DEFAULT CHART FUNCTIONS
+    var defaultTooltipFunction = function () {
+        return function (key, x, y) {
+            return '<h3>' + key + '</h3><p>' + y.formatted_value + '</p>';
+        };
+    };
+    var defaultXFunctionMode = function () {
+        return function (data) {
+            return data.route_type;
+        };
+    };
+    var defaultXFunctionRoute = function () {
+        return function (data) {
+            return data.route_id;
+        };
+    };
+    var defaultYFunction = function () {
+        return function (data) {
+            return data.value;
+        };
+    };
+    var xFunctionZero = function () {
+        return function () {
+            return 0;
+        };
+    };
+    var defaultFilterFunction = function (citydata, aggregation) {
+        return citydata[aggregation];
+    };
+    var defaultForceYFunction = function (data, type, aggregation) {
+        return Math.ceil(data[type][aggregation].max);
+    };
+
+    // Chart configuration
+    otiDataService.Charts = {
+        pie: {
+            xFunctionMode: defaultXFunctionMode,
+            xFunctionRoute: defaultXFunctionRoute,
+            yFunction: defaultYFunction,
+            tooltipFunction: defaultTooltipFunction,
+            filterFunction: function (citydata, aggregation) {
+                if (citydata && citydata[aggregation]) {
+                    return citydata[aggregation][0].values;
+                }
+                return null;
+            }
+        },
+        bar: {
+            xFunctionMode: defaultXFunctionMode,
+            xFunctionRoute: defaultXFunctionRoute,
+            yFunction: defaultYFunction,
+            forceYFunction: defaultForceYFunction,
+            filterFunction: defaultFilterFunction
+        },
+        stacked: {
+            xFunctionMode: xFunctionZero,
+            xFunctionRoute: xFunctionZero,
+            yFunction: defaultYFunction,
+            forceYFunction: defaultForceYFunction,
+            filterFunction: function (citydata, aggregation) {
+                if (!(citydata && citydata[aggregation])) {
+                    return null;
+                }
+                var tempdata = {};
+                _.each(citydata[aggregation][0].values, function (value) {
+                    if (!tempdata[value.route_type]) {
+                        tempdata[value.route_type] = [];
+                    }
+                    tempdata[value.route_type].push(_.extend({}, value));
+                });
+
+                var transformed = [];
+                _.each(tempdata, function (value, key) {
+                    transformed.push({
+                        key: key,
+                        values: value
+                    });
+                });
+                return transformed;
+            },
+            tooltipFunction: function () {
+                return function (key, x, y) {
+                    return '<h3>' + key + '</h3><p>' + y + '</p>';
+                };
+
+            }
+        }
+    };
+
+
     otiDataService.IndicatorConfig = {
         'affordability': {
             'mode': 'bar',
@@ -32,7 +122,7 @@ angular.module('transitIndicators')
             'system': 'number'
         },
         'length': {
-            'mode': 'bar',
+            'mode': 'stacked',
             'system': 'number'
         },
         'line_network_density': {
@@ -84,6 +174,90 @@ angular.module('transitIndicators')
             'mode': 'bar',
             'system': 'number'
         }
+    };
+
+    /**
+     * Transforms the /api/indicators/ response into something that we can use in the graphs/table
+     * source data structure:
+
+[OTIIndicatorService.Indicator]
+
+     * dest data structure:
+
+{
+    "<type>": {
+        "<aggregation>": {
+            max: <number>,
+            min: <number>
+        },
+        "cities": {
+            "<city_name>": {
+                "<aggregation>": [{
+                    key: '<route_type|route_id>',
+                    values: [OTIIndicatorService.Indicator]
+                }]
+            }
+        }
+    }
+}
+
+     * @param source data structure defined above
+     * @return dest data structure defined above
+     */
+    otiDataService.transformData = function (data, cities) {
+        var transformed = {};
+        _.each(data, function (indicator) {
+            if (!transformed[indicator.type]) {
+                transformed[indicator.type] = {
+                    cities: {}
+                };
+            }
+
+            // Calculate max/min for each indicator type
+            if (!transformed[indicator.type].cities[indicator.city_name]) {
+                var indicatorCities = {};
+                // The cities must be set in this object, even if there is no data for that indicator,
+                //  so that we can loop them in the template. If we loop in the template via
+                //  $scope.cities rather than this object, we lose the 2-way binding and updates
+                //  to the indicatorData object no longer update the view.
+                _.each(cities, function (city) {
+                    indicatorCities[city] = {};
+                });
+                transformed[indicator.type].cities = indicatorCities;
+            }
+
+            // Set the indicator into it's proper location
+            if (!transformed[indicator.type].cities[indicator.city_name][indicator.aggregation]) {
+                transformed[indicator.type].cities[indicator.city_name][indicator.aggregation] = [{
+                    key: indicator.aggregation,
+                    values: []
+                }];
+            }
+            transformed[indicator.type].cities[indicator.city_name][indicator.aggregation][0].values.push(indicator);
+
+            // Calculate min/max values of indicator type/aggregation so that
+            //  we can properly scale the graphs
+            if (!transformed[indicator.type][indicator.aggregation]) {
+                transformed[indicator.type][indicator.aggregation] = {
+                    max: Number.NEGATIVE_INFINITY,
+                    min: Number.POSITIVE_INFINITY
+                };
+            }
+            var minmax = transformed[indicator.type][indicator.aggregation];
+            if (indicator.value > minmax.max) {
+                minmax.max = indicator.value;
+            }
+            if (indicator.value < minmax.min) {
+                minmax.min = indicator.value;
+            }
+        });
+        return transformed;
+    };
+
+    otiDataService.getChartTypeForIndicator = function (type) {
+        var config = otiDataService.IndicatorConfig;
+        var chartType = config && config[type] && config[type].mode ? config[type].mode : 'nodata';
+        return chartType;
     };
 
     return otiDataService;

--- a/js/angular/app/scripts/modules/indicators/indicators-service.js
+++ b/js/angular/app/scripts/modules/indicators/indicators-service.js
@@ -92,8 +92,10 @@ angular.module('transitIndicators')
         $http.get('/api/indicator-version/').success(function (data) {
             var version = nullVersion;
             if (data && data.current_versions && !_.isEmpty(data.current_versions)) {
-                console.log(data);
-                version = _.findWhere(data.current_versions, {version__city_name: otiIndicatorsService.selfCityName}).version || nullVersion;
+                var versionObj = _.findWhere(data.current_versions, {version__city_name: otiIndicatorsService.selfCityName});
+                if (versionObj) {
+                    version = versionObj.version;
+                }
             }
             callback(version);
         }).error(function (error) {
@@ -133,6 +135,10 @@ angular.module('transitIndicators')
             dfd.resolve({});
         });
         return dfd.promise;
+    };
+
+    otiIndicatorsService.getIndicatorDescriptionTranslationKey = function(key) {
+        return 'INDICATOR_DESCRIPTION.' + key;
     };
 
     return otiIndicatorsService;


### PR DESCRIPTION
Filters indicator endpoint to only return system/mode indicators

Refactors some of the stuff in data-controller to data-service
and attempts to clean up the chart definition objects.

See notes in data-partial.html regarding use of ng-init
to temporarily store data transformations.
