### PR TITLE
Fix simpleMaxBySystem

### DIFF
--- a/geotrellis/src/main/scala/IndicatorCalculator.scala
+++ b/geotrellis/src/main/scala/IndicatorCalculator.scala
@@ -28,9 +28,12 @@ trait IndicatorCalculator {
   def simpleSumBySystem(period: SamplePeriod): Double = {
     calcByMode(period).toList.foldLeft(0.0){ case(sum, (_, value)) => sum + value }
   }
-  
+
   // Helper function for getting the maximum value obtained in calcByMode.
-  def simpleMaxBySystem(period: SamplePeriod): Double = calcByMode(period).max._2
+  def simpleMaxBySystem(period: SamplePeriod): Double = {
+    val modeResults = calcByMode(period)
+    if (modeResults.isEmpty) 0.0 else modeResults.maxBy(_._2)._2
+  }
 
   // Overall aggregation by route, taking into account all periods
   def calcOverallByRoute: Map[String, Double] = {


### PR DESCRIPTION
This would throw an exception if calcByMode returned an empty map.
Haiphong has no weekend routes, so this was occuring when attempting
to calculate the WeeklyServiceHours indicator on a weekend.

Also, max was returning the calculated value of the mode with the
maximum mode id. It has been changed to maxBy(_._2) in order to return
the maximum calculated value.
