### PR TITLE
Fix overall indicators

### DIFF
--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/Route.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/Route.scala
@@ -33,6 +33,14 @@ object Route {
       def agency = record.agencyId.map(agencies(_))
 
       def trips = t
+
+      // override equals and hashCode so route id is used for comparison
+      override def equals(o: Any) = o match {
+        case that: Route => that.id.equalsIgnoreCase(this.id)
+        case _ => false
+      }
+
+      override def hashCode = id.hashCode
     }
   }
 }

--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/IndicatorsCalculatorSpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/IndicatorsCalculatorSpec.scala
@@ -111,30 +111,24 @@ class IndicatorCalculatorSpec extends FlatSpec with Matchers with IndicatorSpec 
     getResultByRouteId(byRoute, "WTR") should be (3.67724 +- 1e-5)
   }
 
-  // TODO: the results of these tests after the refactor look off
-  // Also one other oddity: I inspected the results of byRoute, and there
-  // were multiple entries in the map for each route, all with different values.
-  // This may be a quirk with all 'overall' calculations, but it hasn't been verified.
-  /*
   it should "calculate overall time_traveled_stops by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(TimeTraveledStops)
 
-    getResultByRouteId(byRoute, "AIR") should be (3.85039 +- 1e-5)
-    getResultByRouteId(byRoute, "CHE") should be (2.81840 +- 1e-5)
-    getResultByRouteId(byRoute, "CHW") should be (3.13225 +- 1e-5)
-    getResultByRouteId(byRoute, "CYN") should be (1.95500 +- 1e-5)
-    getResultByRouteId(byRoute, "FOX") should be (4.08901 +- 1e-5)
-    getResultByRouteId(byRoute, "GLN") should be (0.00000 +- 1e-5)
-    getResultByRouteId(byRoute, "LAN") should be (3.62624 +- 1e-5)
-    getResultByRouteId(byRoute, "MED") should be (2.88720 +- 1e-5)
-    getResultByRouteId(byRoute, "NOR") should be (3.64666 +- 1e-5)
-    getResultByRouteId(byRoute, "PAO") should be (3.08767 +- 1e-5)
-    getResultByRouteId(byRoute, "TRE") should be (4.81956 +- 1e-5)
-    getResultByRouteId(byRoute, "WAR") should be (3.62163 +- 1e-5)
-    getResultByRouteId(byRoute, "WIL") should be (3.22206 +- 1e-5)
-    getResultByRouteId(byRoute, "WTR") should be (3.43258 +- 1e-5)
+    getResultByRouteId(byRoute, "AIR") should be (3.70315 +- 1e-5)
+    getResultByRouteId(byRoute, "CHE") should be (2.81527 +- 1e-5)
+    getResultByRouteId(byRoute, "CHW") should be (3.07009 +- 1e-5)
+    getResultByRouteId(byRoute, "CYN") should be (4.59710 +- 1e-5)
+    getResultByRouteId(byRoute, "FOX") should be (3.93347 +- 1e-5)
+    findRouteById(byRoute.keys, "GLN") should be (None)
+    getResultByRouteId(byRoute, "LAN") should be (3.56027 +- 1e-5)
+    getResultByRouteId(byRoute, "MED") should be (2.91718 +- 1e-5)
+    getResultByRouteId(byRoute, "NOR") should be (3.56457 +- 1e-5)
+    getResultByRouteId(byRoute, "PAO") should be (3.18547 +- 1e-5)
+    getResultByRouteId(byRoute, "TRE") should be (4.79009 +- 1e-5)
+    getResultByRouteId(byRoute, "WAR") should be (3.59415 +- 1e-5)
+    getResultByRouteId(byRoute, "WIL") should be (3.47082 +- 1e-5)
+    getResultByRouteId(byRoute, "WTR") should be (3.45751 +- 1e-5)
   }
- */
 
   it should "calculate time_traveled_stops by system for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = TimeTraveledStops(system)
@@ -245,26 +239,24 @@ class IndicatorCalculatorSpec extends FlatSpec with Matchers with IndicatorSpec 
     byRouteType(Rail) should be (2.31436 +- 1e-5)
   }
 
-  // TODO: the results of these tests after the refactor look off
-  /*
   it should "calcuate distance_between_stops by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(DistanceStops)
 
-    getResultByRouteId(byRoute, "PAO") should be (1.87185 +- 1e-5)
-    getResultByRouteId(byRoute, "MED") should be (1.50170 +- 1e-5)
-    getResultByRouteId(byRoute, "WAR") should be (1.70507 +- 1e-5)
-    getResultByRouteId(byRoute, "NOR") should be (1.75658 +- 1e-5)
-    getResultByRouteId(byRoute, "LAN") should be (2.19893 +- 1e-5)
-    getResultByRouteId(byRoute, "CYN") should be (1.01335 +- 1e-5)
-    getResultByRouteId(byRoute, "WIL") should be (5.45808 +- 1e-5)
-    getResultByRouteId(byRoute, "AIR") should be (1.97381 +- 1e-5)
-    getResultByRouteId(byRoute, "CHW") should be (1.37672 +- 1e-5)
-    getResultByRouteId(byRoute, "WTR") should be (2.30839 +- 1e-5)
-    getResultByRouteId(byRoute, "FOX") should be (1.67826 +- 1e-5)
-    getResultByRouteId(byRoute, "CHE") should be (1.04458 +- 1e-5)
-    getResultByRouteId(byRoute, "TRE") should be (5.58536 +- 1e-5)
+    getResultByRouteId(byRoute, "AIR") should be (1.90437 +- 1e-5)
+    getResultByRouteId(byRoute, "CHE") should be (1.00636 +- 1e-5)
+    getResultByRouteId(byRoute, "CHW") should be (1.32695 +- 1e-5)
+    getResultByRouteId(byRoute, "CYN") should be (2.41703 +- 1e-5)
+    getResultByRouteId(byRoute, "FOX") should be (1.55288 +- 1e-5)
+    findRouteById(byRoute.keys, "GLN") should be (None)
+    getResultByRouteId(byRoute, "LAN") should be (2.08694 +- 1e-5)
+    getResultByRouteId(byRoute, "MED") should be (1.59278 +- 1e-5)
+    getResultByRouteId(byRoute, "NOR") should be (1.72959 +- 1e-5)
+    getResultByRouteId(byRoute, "PAO") should be (1.80415 +- 1e-5)
+    getResultByRouteId(byRoute, "TRE") should be (5.39617 +- 1e-5)
+    getResultByRouteId(byRoute, "WAR") should be (1.75354 +- 1e-5)
+    getResultByRouteId(byRoute, "WIL") should be (5.30987 +- 1e-5)
+    getResultByRouteId(byRoute, "WTR") should be (2.20600 +- 1e-5)
   }
-  */
 
   it should "calcuate overall distance_between_stops by system for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(DistanceStops)

--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/NumRoutesSpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/NumRoutesSpec.scala
@@ -20,8 +20,6 @@ class NumRoutesSpec extends FlatSpec with Matchers with IndicatorSpec {
     byRouteType(Rail) should be (12.45833 +- 1e-5)
   }
 
-  // TODO: the results to the following two tests after the refactor look off
-  /*
   it should "calculate num_routes by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = NumRoutes(system)
 
@@ -43,22 +41,21 @@ class NumRoutesSpec extends FlatSpec with Matchers with IndicatorSpec {
   it should "calculate overall num_routes by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(NumRoutes)
 
-    getResultByRouteId(byRoute, "AIR") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "CHE") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "CHW") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "CYN") should be (0.4017 +- 1e-4)
-    getResultByRouteId(byRoute, "FOX") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "GLN") should be (0.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "LAN") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "MED") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "NOR") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "PAO") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "TRE") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "WAR") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "WIL") should be (1.0000 +- 1e-4)
-    getResultByRouteId(byRoute, "WTR") should be (1.0000 +- 1e-4)
+    getResultByRouteId(byRoute, "AIR") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "CHE") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "CHW") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "CYN") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "FOX") should be (0.9583 +- 1e-4)
+    findRouteById(byRoute.keys, "GLN") should be (None)
+    getResultByRouteId(byRoute, "LAN") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "MED") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "NOR") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "PAO") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "TRE") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "WAR") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "WIL") should be (0.9583 +- 1e-4)
+    getResultByRouteId(byRoute, "WTR") should be (0.9583 +- 1e-4)
   }
-   */
 
   it should "calculate num_routes by system for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = NumRoutes(system)

--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/NumStopsSpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/NumStopsSpec.scala
@@ -43,27 +43,24 @@ class NumStopsSpec extends FlatSpec with Matchers with IndicatorSpec {
     getResultByRouteId(byRoute, "WTR") should be (23)
   }
 
-  // TODO: the results of these tests after the refactor look off
-  /*
   it should "calculate overall num_stops by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(NumStops)
 
-    getResultByRouteId(byRoute, "AIR") should be ( 9.99988 +- 1e-5)
-    getResultByRouteId(byRoute, "CHE") should be (14.68733 +- 1e-5)
-    getResultByRouteId(byRoute, "CHW") should be (13.99983 +- 1e-5)
-    getResultByRouteId(byRoute, "CYN") should be ( 2.00892 +- 1e-5)
-    getResultByRouteId(byRoute, "FOX") should be ( 9.71417 +- 1e-5)
-    getResultByRouteId(byRoute, "GLN") should be ( 0.00000 +- 1e-5)
-    getResultByRouteId(byRoute, "LAN") should be (24.68423 +- 1e-5)
-    getResultByRouteId(byRoute, "MED") should be (18.99978 +- 1e-5)
-    getResultByRouteId(byRoute, "NOR") should be (16.99980 +- 1e-5)
-    getResultByRouteId(byRoute, "PAO") should be (25.99969 +- 1e-5)
-    getResultByRouteId(byRoute, "TRE") should be (14.77662 +- 1e-5)
-    getResultByRouteId(byRoute, "WAR") should be (16.99980 +- 1e-5)
-    getResultByRouteId(byRoute, "WIL") should be (20.07121 +- 1e-5)
-    getResultByRouteId(byRoute, "WTR") should be (22.38963 +- 1e-5)
+    getResultByRouteId(byRoute, "AIR") should be ( 9.58333 +- 1e-5)
+    getResultByRouteId(byRoute, "CHE") should be (14.13690 +- 1e-5)
+    getResultByRouteId(byRoute, "CHW") should be (13.41666 +- 1e-5)
+    getResultByRouteId(byRoute, "CYN") should be ( 4.79166 +- 1e-5)
+    getResultByRouteId(byRoute, "FOX") should be (10.00595 +- 1e-5)
+    findRouteById(byRoute.keys, "GLN") should be (None)
+    getResultByRouteId(byRoute, "LAN") should be (25.48809 +- 1e-5)
+    getResultByRouteId(byRoute, "MED") should be (18.20833 +- 1e-5)
+    getResultByRouteId(byRoute, "NOR") should be (16.29166 +- 1e-5)
+    getResultByRouteId(byRoute, "PAO") should be (24.91666 +- 1e-5)
+    getResultByRouteId(byRoute, "TRE") should be (14.37500 +- 1e-5)
+    getResultByRouteId(byRoute, "WAR") should be (16.77380 +- 1e-5)
+    getResultByRouteId(byRoute, "WIL") should be (20.93452 +- 1e-5)
+    getResultByRouteId(byRoute, "WTR") should be (22.04166 +- 1e-5)
   }
-  */
 
   it should "calculate num_stops by system for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = NumStops(system)


### PR DESCRIPTION
When calculating the overall indicators, the PeriodResultAggregator
uses combineMaps, which uses groupBy to combine the calculation results.
The key of the map is a Route object, and since equals and hashCode
weren't defined on Route, groupBy wasn't able to properly group them.
