### PR TITLE
Feature/improve feed upload feedback

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/service/IngestRoute.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/service/IngestRoute.scala
@@ -23,17 +23,32 @@ trait IngestRoute extends Route { self: DatabaseInstance =>
       post {
         parameter('gtfsDir.as[String]) { gtfsDir =>
           complete {
+            var err: JsObject = null
             TaskQueue.execute {
               println(s"parsing GTFS data from: $gtfsDir")
               val routeCount =
                 db withSession { implicit session =>
-                  timedTask("Ingested GTFS") { GtfsIngest(gtfsDir) }
+                  try {
+                    timedTask("Ingested GTFS") { GtfsIngest(gtfsDir) }
+                    } catch {
+                      case e: Exception =>
+                        println("Error parsing GTFS!")
+                        println(e.getMessage)
+                        println(e.getStackTrace.mkString("\n"))
+                        err = JsObject(
+                          "success" -> JsBoolean(false),
+                          "message" -> JsString("Error parsing GTFS.\n" + 
+                                                e.getMessage.replace("\"", "'"))
+                        )
+                    }
                 }
 
-              JsObject(
-                "success" -> JsBoolean(true),
-                "message" -> JsString(s"Imported $routeCount routes")
-              )
+              if (err == null)
+                JsObject(
+                  "success" -> JsBoolean(true),
+                  "message" -> JsString(s"Imported $routeCount routes")
+                )
+              else err
             }
           }
         }

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/service/OpenTransitServiceActor.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/service/OpenTransitServiceActor.scala
@@ -45,18 +45,8 @@ class OpenTransitServiceActor extends Actor
   }
 
   // This will be picked up by the runRoute(_) and used to intercept Exceptions
-  def OpenTransitGeoTrellisExceptionHandler(implicit log: LoggingContext) =
+  implicit def OpenTransitGeoTrellisExceptionHandler(implicit log: LoggingContext) =
     ExceptionHandler {
-      case ex: java.util.NoSuchElementException =>
-        requestUri { uri =>
-          println("Got a NoSuchElementException!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-          log.warning("Something went wrong here.......................................")
-          println(ex.getMessage)
-          println(ex.getStackTrace.mkString("\n"))
-          // replace double quotes with single so our message is more json safe
-          val jsonMessage = ex.getMessage.replace("\"", "'")
-          complete(InternalServerError, s"""{ "success": false, "message": "${jsonMessage}" }""" )
-        }
       case e: Exception =>
         requestUri { uri =>
           // print error message and stack trace to console so we dont have to go a-hunting
@@ -66,7 +56,7 @@ class OpenTransitServiceActor extends Actor
           println(e.getStackTrace.mkString("\n"))
           // replace double quotes with single so our message is more json safe
           val jsonMessage = e.getMessage.replace("\"", "'")
-          complete(InternalServerError, s"""{ "success": false, "message": "${jsonMessage}" }""" )
+          complete(future(InternalServerError, s"""{ "success": false, "message": "${jsonMessage}" }""" ))
         }
     }
 }


### PR DESCRIPTION
This is to fix #265.  If an error is encountered parsing GTFS, it will return the error message as JSON.  Also, if the celery feed import task gets a spray response that is not JSON, it will fall back to reading it as a text string.

It would probably be best to figure out why `OpenTransitGeoTrellisExceptionHandler` in `OpenTransitServiceActor` isn't actually catching errors from `ingestRoute`; it's not apparent to me why that's happening.
