### PR TITLE
Update Length tests

### DIFF
--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/LengthSpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/LengthSpec.scala
@@ -31,6 +31,10 @@ class LengthSpec extends FlatSpec with Matchers with IndicatorSpec {
     val AggregatedResults(byRoute, byRouteType, bySystem) = calculation(system)
     implicit val routeMap = byRoute
 
+    // NOTE: These are results for SEPTA regional rail, but the trip shapes
+    // for SEPTA are completely messed up, so these shouldn't be taken as
+    // representing actual values for SEPTA, but rather indicators of whether
+    // the indicator calculations remain consistent.
     getResultByRouteId(byRoute, "AIR") should be ( 21.86907 +- 1e-5)
     getResultByRouteId(byRoute, "CHE") should be ( 22.47520 +- 1e-5)
     getResultByRouteId(byRoute, "CHW") should be ( 23.38168 +- 1e-5)

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/Length.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/Length.scala
@@ -10,8 +10,12 @@ object Length extends Indicator
 
   val name = "length"
 
-  // TODO: Rob pointed out during the refactor walkthrough that this calculation
-  // is not correct and needs tweaking (particularly eliminating the max logic).
+  // NOTE: This calculation is not correct in all circumstances; that is, the trip
+  // with the maximum number of stops may not contain every stop on the route, and
+  // might therefore be shorter than the actual length of the route. However, this
+  // has been determined to be close enough for now.
+  // TODO: Fix this if there is time or an edge case in which it makes a significant
+  // difference.
   def calculation(period: SamplePeriod) = {
     def map(trips: Seq[Trip]): Double =
       trips.foldLeft(0.0) { (maxLength, trip) =>


### PR DESCRIPTION
This updates the length tests so that they work with the new testing scheme.

The SEPTA numbers are not correct because of the problems with the SEPTA data; they just let us know when something has changed. There are also tests with the ad-hoc system which verify that things are working correctly.
