### PR TITLE
Parse stops after routes and trips.

### DIFF
--- a/deployment/stops_routes_trigger.sql
+++ b/deployment/stops_routes_trigger.sql
@@ -3,36 +3,34 @@ DROP TRIGGER IF EXISTS stops_routes on gtfs_stops;
 
 CREATE OR REPLACE FUNCTION stops_routes() RETURNS trigger AS $stops_routes$
     BEGIN
+        DELETE FROM gtfs_stops_routes_join;
+        DELETE FROM gtfs_stops_info;
+
         -- Repopulate gtfs_stops_routes_join table
-        
         EXECUTE 'INSERT INTO gtfs_stops_routes_join (
             SELECT DISTINCT st.stop_id, r.route_id
             FROM gtfs_stop_times st
             LEFT JOIN gtfs_trips t ON st.trip_id = t.trip_id
             LEFT JOIN gtfs_routes r on r.route_id = t.route_id
-            LEFT JOIN gtfs_stops s on s.stop_id = st.stop_id
-            WHERE s.stop_id = $1
-        )' USING NEW.stop_id;
+            LEFT JOIN gtfs_stops s on s.stop_id = st.stop_id)';
 
         -- Populate routes_desc column on stops table for UTFGrid interactivity;
         -- show stop description and the routes it serves.
-        EXECUTE 'INSERT INTO gtfs_stops_info (SELECT s.stop_id, s.the_geom,
+        EXECUTE 'INSERT INTO gtfs_stops_info (SELECT DISTINCT s.stop_id, s.the_geom,
             CONCAT(''<strong>'', s.stop_name, ''</strong><br />'',
                 array_to_string(array(
                     SELECT r.route_short_name
                     FROM gtfs_routes AS r INNER JOIN gtfs_stops_routes_join AS srj
                     ON (srj.route_id = r.route_id)
-                    WHERE srj.stop_id = $1
+                    WHERE srj.stop_id = s.stop_id
                 ), ''<br />'')
             )
-            FROM gtfs_stops s
-            WHERE s.stop_id=$1)'
-        USING NEW.stop_id;
+            FROM gtfs_stops s)';
 
         RETURN NEW;
     END;
 $stops_routes$ LANGUAGE plpgsql;
 
 CREATE TRIGGER stops_routes AFTER INSERT ON gtfs_stops
-    FOR EACH ROW EXECUTE PROCEDURE stops_routes();
+    FOR EACH STATEMENT EXECUTE PROCEDURE stops_routes();
 

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/io/csv/CsvGtfsRecords.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/io/csv/CsvGtfsRecords.scala
@@ -49,9 +49,6 @@ class CsvGtfsRecords(dir: String) extends GtfsRecords {
   def agencies: Seq[Agency] =
     parse(AgencyFile)
 
-  def stops: Seq[Stop] =
-    parse(StopsFile)
-
   def routeRecords: Seq[RouteRecord] = 
     parse(RoutesFile)
 
@@ -72,4 +69,7 @@ class CsvGtfsRecords(dir: String) extends GtfsRecords {
 
   def frequencyRecords: Seq[FrequencyRecord] = 
     parse(FrequenciesFile)
+
+  def stops: Seq[Stop] =
+    parse(StopsFile)
 }

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/DatabaseGtfsRecords.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/DatabaseGtfsRecords.scala
@@ -22,7 +22,6 @@ class DatabaseGtfsRecords(implicit session: Session)
   def force: GtfsRecords =
     new GtfsRecords {
       val agencies: Seq[Agency] = DatabaseGtfsRecords.this.agencies
-      val stops: Seq[Stop] = DatabaseGtfsRecords.this.stops
       val routeRecords: Seq[RouteRecord] = DatabaseGtfsRecords.this.routeRecords
       val tripRecords: Seq[TripRecord] = DatabaseGtfsRecords.this.tripRecords
       val stopTimeRecords: Seq[StopTimeRecord] = DatabaseGtfsRecords.this.stopTimeRecords
@@ -30,5 +29,6 @@ class DatabaseGtfsRecords(implicit session: Session)
       val calendarDateRecords: Seq[CalendarDateRecord] = DatabaseGtfsRecords.this.calendarDateRecords
       val tripShapes: Seq[TripShape] = DatabaseGtfsRecords.this.tripShapes
       val frequencyRecords: Seq[FrequencyRecord] = DatabaseGtfsRecords.this.frequencyRecords
+      val stops: Seq[Stop] = DatabaseGtfsRecords.this.stops
     }
 }

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/DatabaseRecordImport.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/DatabaseRecordImport.scala
@@ -14,7 +14,9 @@ class DatabaseRecordImport(override val geomColumnName: String = Profile.default
   import profile.simple._
 
   private def load[T, U <: Table[T]](records: Seq[T], table: TableQuery[U]): Unit = {
-    table.forceInsertAll(records:_*)
+    session.withTransaction {
+      table.forceInsertAll(records:_*)
+    }
   }
 
   private def deleteAll(): Unit = {
@@ -39,7 +41,6 @@ class DatabaseRecordImport(override val geomColumnName: String = Profile.default
     }
 
     timedTask("loaded agencies") { load(records.agencies, agenciesTable) }
-    timedTask("loaded stops") { load(records.stops, stopsTable) }
     timedTask("loaded calendar dates") {
       load(records.calendarDateRecords, calendarDateRecordsTable)
     }
@@ -51,5 +52,6 @@ class DatabaseRecordImport(override val geomColumnName: String = Profile.default
     }
     timedTask("loaded frequencies") { load(records.frequencyRecords, frequencyRecordsTable) }
     timedTask("loaded trip shapes") { load(records.tripShapes, tripShapesTable) }
+    timedTask("loaded stops") { load(records.stops, stopsTable) }
   }
 }


### PR DESCRIPTION
Fixes issue where database trigger to find routes served by stop finds no served routes.

Also makes database trigger statement-level rather than row-level, which will probably be necessary for scenarios.

Closes #313.
