### PR TITLE
Refine checkmark logic to exclude configurations that lack boundary size

### DIFF
--- a/js/angular/app/scripts/modules/settings/settings-controller.js
+++ b/js/angular/app/scripts/modules/settings/settings-controller.js
@@ -44,9 +44,9 @@ angular.module('transitIndicators')
         // GTFS
         $scope.gtfsData = gtfsData.$promise.then(function(response) {
             var validGtfs = _.filter(response, function(upload) {
-                return upload.status == 'complete';
+                return upload.status === 'complete';
             });
-            $scope.checkmarks['upload'] = validGtfs.length > 0;
+            $scope.checkmarks.upload = validGtfs.length > 0;
             return response[0];
         });
 
@@ -55,37 +55,43 @@ angular.module('transitIndicators')
             if (!(response && response.length)) {
                 return;
             }
-            var config = response[0];
+            var demographics = response[0];
             $scope.assign = {
-                pop_metric_1: config.pop_metric_1_field || null,
-                pop_metric_2: config.popmetric_2_field || null,
-                dest_metric_1: config.destmetric_1_field || null
+                pop_metric_1: demographics.pop_metric_1_field || null,
+                pop_metric_2: demographics.popmetric_2_field || null,
+                dest_metric_1: demographics.destmetric_1_field || null
             };
-            $scope.checkmarks['demographic'] = true;
-            return config;
+            $scope.checkmarks.demographic = true;
+            return demographics;
         });
 
         // REALTIME
         $scope.realtimeData = realtimeData.$promise.then(function(response){
             var validRealtime = _.filter(response, function(upload) {
-                return upload.status == 'complete';
+                return upload.status === 'complete';
             });
-            $scope.checkmarks['realtime'] = validRealtime.length > 0;
+            $scope.checkmarks.realtime = validRealtime.length > 0;
             return response[0];
         });
 
-        // BOUNDARY
-        $scope.configData = configData.$promise.then(function(response) {
-            var cityId = response[0].city_boundary;
-            var regId = response[0].region_boundary;
-            $scope.checkmarks['boundary'] = typeof(cityId) === "number" && typeof(regId) === "number";
-            return response[0];
+        $scope.configData = configData.$promise.then(function(configResponse) {
+            // BOUNDARY
+            var cityId = configResponse[0].city_boundary;
+            var regId = configResponse[0].region_boundary;
+            $scope.checkmarks.boundary = typeof(cityId) === 'number' && typeof(regId) === 'number';
+
+            return configResponse[0];
         });
 
         // SAMPLE PERIODS
-        $scope.samplePeriod = samplePeriodData.$promise.then(function(response) {
-            $scope.checkmarks['configuration'] = response.length > 0;
+        $scope.samplePeriod = samplePeriodData.$promise.then(function(samplePeriods) {
+            configData = configData.$promise.then(function(configResponse) {
+                $scope.checkmarks.configuration = samplePeriods.length > 0 && configResponse[0].nearby_buffer_distance_m > 0;
+            });
+            return samplePeriods.slice(0,-1);
         });
+
+
     };
 
     $scope.$on('$stateChangeSuccess', function (event, toState) {


### PR DESCRIPTION
This tightens the checkmark logic up a bit such that iff buffers are greater than one and more than 'all-time' dates are selected, a checkmark will appear next to 'Configuration'.
