### PR TITLE
Add calculation of missing indicators

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/Indicator.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/Indicator.scala
@@ -41,6 +41,10 @@ object Indicators {
         Requires()
       ),
       (
+        new RoadLengthRatio(params),
+        Requires()
+      ),
+      (
         new CoverageRatioStopsBuffer(params),
         Requires(settings.hasCityBounds)
       ),
@@ -59,6 +63,10 @@ object Indicators {
       (
         new DwellTimePerformance(params),
         Requires(settings.hasObserved)
+      ),
+      (
+        new RatioSuburbanLines(params),
+        Requires(settings.hasCityBounds)
       ),
       (
         new AllWeightedServiceFrequency(params),


### PR DESCRIPTION
Though indicators were defined for `lines_roads` and `ratio_suburban_lines`, they weren't actually being run.  This fixes that.  (They seem to be running fine; I assume leaving them out was an oversight.)
