### PR TITLE
Fix scenario creation test

### DIFF
--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/DatabaseTests.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/DatabaseTests.scala
@@ -77,9 +77,7 @@ class DatabaseTests extends FunSuite with DatabaseTestFixture with Matchers {
     )
 
     // Create the scenario
-    CreateScenario(request, dbByName) { status =>
-      status should be (JobStatus.Complete)
-    }
+    CreateScenario(request, dbByName)
 
     // Load the scenario and verify data is present
     dbByName(scenarioDbName) withSession { implicit session: Session =>


### PR DESCRIPTION
The signature of CreateScenario changed on the scenarios REST endpoint branch -- it no longer uses a sink function, as the status is handled elsewhere.
