### PR TITLE
Add user-configurable city name

### DIFF
--- a/js/angular/app/i18n/en.json
+++ b/js/angular/app/i18n/en.json
@@ -223,6 +223,7 @@
         },
         "TOOLTIP": {
             "CITY": "The Area of Interest boundary will be used to define a subregion of the transit system area served, such as a business district or city center.",
+            "CITY_NAME": "The name that will be displayed for identifying calculations made from this feed.",
             "REGION": "This boundary should represent the total area served by the transit system.",
             "REPRESENTATIVE_WEEKDAY": "Please choose a weekday during which the system is scheduled for normal service.",
             "REPRESENTATIVE_WEEKEND": "Please choose a weekend day during which the system is scheduled for normal service.",
@@ -238,6 +239,7 @@
     "SETTINGS": {
         "BOUNDARY_DESCRIPTION": "Please upload two boundary files as zipped Shapefiles (SHP). The application will use these boundaries to calculate accessibility and performance metrics about your GTFS data. One of the files would highlight an area of interest such as a city center, or area of job centers, for example. The second boundary should encompass the overall region served by the transit system.",
         "CITY": "Area of Interest",
+        "CITY_NAME": "City Name",
         "CITY_ERRORS": "Area of Interest Errors",
         "CITY_WARNINGS": "Area of Interest Warnings",
         "REGION": "Region",

--- a/js/angular/app/i18n/es.json
+++ b/js/angular/app/i18n/es.json
@@ -221,6 +221,7 @@
         },
         "TOOLTIP": {
             "CITY": "!The Area of Interest boundary will be used to define a subregion of the transit system area served, such as a business district or city center.",
+            "CITY_NAME": "The name that will be displayed for identifying calculations made from this feed.",
             "REGION": "!This boundary should represent the total area served by the transit system.",
             "REPRESENTATIVE_WEEKDAY": "!Please choose a weekday during which the system is scheduled for normal service.",
             "REPRESENTATIVE_WEEKEND": "!Please choose a weekend day during which the system is scheduled for normal service.",
@@ -236,6 +237,7 @@
     "SETTINGS": {
         "BOUNDARY_DESCRIPTION": "!Please upload two boundary files as zipped Shapefiles (SHP). The application will use these boundaries to calculate accessibility and performance metrics about your GTFS data. One of the files would highlight an area of interest such as a city center, or area of job centers, for example. The second boundary should encompass the overall region served by the transit system.",
         "CITY": "!Area of Interest",
+        "CITY_NAME": "City Name",
         "CITY_ERRORS": "!Area of Interest Errors",
         "CITY_WARNINGS": "!Area of Interest Warnings",
         "REGION": "!Region",

--- a/js/angular/app/i18n/vi.json
+++ b/js/angular/app/i18n/vi.json
@@ -221,6 +221,7 @@
         },
         "TOOLTIP": {
             "CITY": "Phạm vi giới hạn khu vực cần phân tích sẽ được sử dụng để thể hiện một phân vùng trong hệ thống như khu thương mai, trung tâm thành phố",
+            "CITY_NAME": "The name that will be displayed for identifying calculations made from this feed.",
             "REGION": "Phạm vi giới hạn thể hiện toàn bộ phạm vi phục vụ của hệ thống",
             "REPRESENTATIVE_WEEKDAY": "Chọn một ngày trong tuần với chế độ phục vụ bình thường",
             "REPRESENTATIVE_WEEKEND": "Chọn ngày cuối tuần với chế độ phục vụ bình thường",
@@ -236,6 +237,7 @@
     "SETTINGS": {
         "BOUNDARY_DESCRIPTION": "Chọn tải lên 2 tệp tin giới hạn phạm vi hoạt động dưới định dạng nén như Shapefiles (SHP ). Chương trình sẽ sử dụng các giới hạn này để tính toán khả năng rời cập bến và thể hiện các số liệu thống kê từ dữ liệu GTFS. Một trong các tệp tin sẽ đánh dấu một khu vực cần phân tích, ví dụ như là một trung tâm thành phố hay một trung tâm tập trung nhiều người lao động hay khu công nghiệp. Tệp tin thứ hai sẽ chứa khu vực tổng thể được phục vụ bởi hệ thống giao thông.",
         "CITY": "Khu vực cần phân tích",
+        "CITY_NAME": "City Name",
         "CITY_ERRORS": "Lỗi thuộc khu vực cần phân tích",
         "CITY_WARNINGS": "Cảnh báo thuộc khu vực cần phân tích",
         "REGION": "Khu vực tổng thể",

--- a/js/angular/app/i18n/zh.json
+++ b/js/angular/app/i18n/zh.json
@@ -221,6 +221,7 @@
         },
         "TOOLTIP": {
             "CITY": "关注区域的边界将被用于定义所服务公交系统区域的一个分区，如某个商业区或城市中心。",
+            "CITY_NAME": "The name that will be displayed for identifying calculations made from this feed.",
             "REGION": "本边界应代表公交系统所服务的总区域。",
             "REPRESENTATIVE_WEEKDAY": "请选择一个系统按计划正常服务的平常日。",
             "REPRESENTATIVE_WEEKEND": "请选择一个系统按计划正常服务的周末日。",
@@ -236,6 +237,7 @@
     "SETTINGS": {
         "BOUNDARY_DESCRIPTION": "请上传两个边界文件（压缩Shapefile（SHP）格式文件）。应用程序将利用这些边界计算您的GTFS数据的可达性和性能度量指标。其中一个文件将突出显示某个关注区域，如城市中心或存在就业中心的区域。第二个边界应包容公交系统所服务的整个地区。",
         "CITY": "关注区域",
+        "CITY_NAME": "City Name",
         "CITY_ERRORS": "关注区域错误",
         "CITY_WARNINGS": "关注区域警告",
         "REGION": "地区",

--- a/js/angular/app/scripts/modules/indicators/indicators-service.js
+++ b/js/angular/app/scripts/modules/indicators/indicators-service.js
@@ -2,14 +2,12 @@
 
 angular.module('transitIndicators')
 .factory('OTIIndicatorsService',
-        ['$q', '$http', '$resource',
-        function ($q, $http, $resource) {
+        ['$q', '$http', '$resource', 'OTIUploadService',
+        function ($q, $http, $resource, OTIUploadService) {
 
     var otiIndicatorsService = {};
     var nullVersion = 0;
-    // TODO: Replace this with call to get user-defined city name once implemented
-    // Should equal django.conf.settings.OTI_CITY_NAME
-    otiIndicatorsService.selfCityName = 'My City';
+    otiIndicatorsService.selfCityName = null;
 
     otiIndicatorsService.Indicator = $resource('/api/indicators/:id/ ', {id: '@id'}, {
         'update': {
@@ -95,7 +93,12 @@ angular.module('transitIndicators')
      * @param callback: function to call after request is made, has a single argument 'version'
      */
     otiIndicatorsService.getIndicatorVersion = function (callback) {
-        $http.get('/api/indicator-version/').success(function (data) {
+        var promises = []; // get the city name before using it to filter indicator versions
+        promises.push(OTIUploadService.cityName.get({}, function (data) {
+            otiIndicatorsService.selfCityName = data.city_name;
+        }));
+
+        promises.push($http.get('/api/indicator-version/').success(function (data) {
             var version = nullVersion;
             if (data && data.current_versions && !_.isEmpty(data.current_versions)) {
                 var versionObj = _.findWhere(data.current_versions, {version__city_name: otiIndicatorsService.selfCityName});
@@ -107,7 +110,9 @@ angular.module('transitIndicators')
         }).error(function (error) {
             console.error('getIndicatorVersion:', error);
             callback(nullVersion);
-        });
+        }));
+
+        $q.all(promises);
     };
 
     otiIndicatorsService.getIndicatorTypes = function () {

--- a/js/angular/app/scripts/modules/settings/upload/upload-controller.js
+++ b/js/angular/app/scripts/modules/settings/upload/upload-controller.js
@@ -33,6 +33,13 @@ angular.module('transitIndicators')
     ['$scope', '$rootScope', '$timeout', '$upload', 'OTIUploadService', 'OTIEvents',
     function ($scope, $rootScope, $timeout, $upload, OTIUploadService, OTIEvents) {
 
+    $scope.cityName = null;
+
+    $scope.saveCityNameButton = {
+        text: 'STATUS.SAVE',
+        enabled: false // enable save button once city name has been changed
+    };
+
     /**
      * Clears the uploadProblems dict
      */
@@ -204,6 +211,36 @@ angular.module('transitIndicators')
         $rootScope.$broadcast(OTIEvents.Settings.Upload.GTFSDelete);
     });
 
+    $scope.saveCityName = function () {
+        $scope.saveCityNameButton.enabled = false;
+        $scope.saveCityNameButton.text = 'STATUS.SAVING';
+        OTIUploadService.cityName.save({'city_name': $scope.cityName}, function () {
+            $scope.saveCityNameButton.enabled = true;
+            $scope.saveCityNameButton.text = 'STATUS.SAVE';
+        }, function (error) {
+            $scope.saveCityNameButton.enabled = true;
+            $scope.saveCityNameButton.text = 'STATUS.SAVE';
+
+            // ignore error if attempt to save unchanged city name
+            if (error.data.city_name && error.data.city_name[0].indexOf('already exists') === -1) {
+                $scope.cityNameError = true;
+            } else {
+                console.log('error saving city name:');
+                console.log(error.data);
+            }
+            
+        });
+    };
+
+    // disable save button is city name field is empty
+    $scope.checkCityName = function () {
+        if ($scope.cityName) {
+            $scope.saveCityNameButton.enabled = true;
+        } else {
+            $scope.saveCityNameButton.enabled = false;
+        }
+    };
+
     // Set initial scope variables and constants
     $scope.gtfsUpload = {};
     $scope.gtfsOptions = {
@@ -227,6 +264,10 @@ angular.module('transitIndicators')
                     checkOSMImport($scope.gtfsUpload);
                 }
             }
+        });
+
+        OTIUploadService.cityName.get({}, function (data) {
+            $scope.cityName = data.city_name;
         });
     };
 }]);

--- a/js/angular/app/scripts/modules/settings/upload/upload-partial.html
+++ b/js/angular/app/scripts/modules/settings/upload/upload-partial.html
@@ -2,6 +2,28 @@
     <h1>{{'VIEW.upload' | translate}}</h1>
     <p>{{'SETTINGS.UPLOAD_DESCRIPTION' | translate}}</p>
 
+    <form ng-submit="saveCityName()" name="cityNameForm" ng-show="true" autocomplete="off">
+        <div class="settingsmodal-fieldgroup">
+            <div class="row">
+                <div class="col-sm-12">
+                    <div class="row">
+                        <div class="col-sm-9">
+                            <span class="h4"><span tooltip="{{ 'UI.TOOLTIP.CITY_NAME' | translate }}"
+                                class="glyphicon glyphicon-info-sign"></span> {{'SETTINGS.CITY_NAME' | translate}}</span>
+                        </div>
+                        <div class="col-sm-3">
+                            <input type="text" name="cityName" ng-model="cityName" required="true" ng-change="checkCityName()">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <button ng-disabled="!saveCityNameButton.enabled" class="btn" 
+            ng-class="{'btn-primary': saveCityNameButton.enabled}">{{saveCityNameButton.text | translate}}</button>
+        <span ng-show="cityNameError" class="label label-danger">{{'TERM.ERROR' | translate}}</span>
+    </form><br />
+
     <polling-upload url="/api/gtfs-feeds/" upload="gtfsUpload" resource="GTFSUploads" options="gtfsOptions">
     </polling-upload>
 
@@ -23,7 +45,9 @@
     </div>
 
     <div class="dropzone error" ng-if="Status.isError(osmImport.status)">
-      <div class="h4">{{'SETTINGS.OSM_IMPORT_ERROR' | translate}} <span class="h5 pull-right"><button class="btn btn-danger" ng-click="retryOSMImport()">{{'STATUS.RETRY' | translate}}</button></span></div>
+        <div class="h4">{{'SETTINGS.OSM_IMPORT_ERROR' | translate}} <span class="h5 pull-right">
+            <button class="btn btn-danger" ng-click="retryOSMImport()">{{'STATUS.RETRY' | translate}}</button></span>
+        </div>
     </div>
 
     <div class="dropzone inprogress" ng-show="Status.isPolling(osmImport.status)">

--- a/js/angular/app/scripts/modules/settings/upload/upload-service.js
+++ b/js/angular/app/scripts/modules/settings/upload/upload-service.js
@@ -16,6 +16,14 @@ angular.module('transitIndicators')
         }
     });
 
+    // OTI city name
+    otiuploadservice.cityName = $resource('/api/city-name/ ', {}, {
+        'save': {
+            method: 'POST',
+            url: '/api/city-name/ '
+        }
+    });
+
     // OTI data problems
     otiuploadservice.gtfsProblems = $resource('/api/gtfs-feed-problems/:id');
 

--- a/python/django/transit_indicators/migrations/0037_auto_20141024_1654.py
+++ b/python/django/transit_indicators/migrations/0037_auto_20141024_1654.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import transit_indicators.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transit_indicators', '0036_update_indicator_choices'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OTICityName',
+            fields=[
+                ('city_name', models.CharField(max_length=255, serialize=False, primary_key=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterField(
+            model_name='indicatorjob',
+            name='city_name',
+            field=models.CharField(default=transit_indicators.models.get_city_name, max_length=255),
+        ),
+    ]

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -27,6 +27,15 @@ class GTFSRouteType(models.Model):
     class Meta(object):
         db_table = 'gtfs_route_types'
 
+class OTICityName(models.Model):
+    """ User-configurable name for their city; set with GTFS upload.
+        There should only be a single entry in this table at any time.
+    """
+    city_name = models.CharField(blank=False, max_length=255, primary_key=True)
+
+    def __unicode__(self):
+        return self.city_name
+
 
 class OTIIndicatorsConfig(models.Model):
     """ Global configuration for indicator calculation. """
@@ -162,6 +171,16 @@ class Scenario(models.Model):
     description = models.CharField(max_length=255, blank=True, null=True)
 
 
+""" Helper method to find the city name set for the database.
+"""
+def get_city_name():
+    try:
+        city_name = OTICityName.objects.get().city_name
+    except OTICityName.DoesNotExist:
+        city_name = settings.OTI_CITY_NAME
+    return city_name
+
+
 class IndicatorJob(models.Model):
     """Stores processing status of an indicator job"""
 
@@ -189,7 +208,7 @@ class IndicatorJob(models.Model):
 
     # A city name used to differentiate indicator sets
     # external imports must provide a city name as part of the upload
-    city_name = models.CharField(max_length=255, default=settings.OTI_CITY_NAME)
+    city_name = models.CharField(max_length=255, default=get_city_name)
 
     # json string map of indicator name to status
     calculation_status = models.TextField(default='{}')

--- a/python/django/transit_indicators/serializers.py
+++ b/python/django/transit_indicators/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from datasources.models import DemographicDataFieldName
 from transit_indicators.models import (OTIIndicatorsConfig, OTIDemographicConfig, SamplePeriod,
-                                       Indicator, IndicatorJob, Scenario)
+                                       Indicator, IndicatorJob, Scenario, OTICityName)
 from userdata.models import OTIUser
 
 class SamplePeriodSerializer(serializers.ModelSerializer):
@@ -229,3 +229,8 @@ class OTIDemographicConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OTIDemographicConfig
+
+
+class OTICityNameSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OTICityName

--- a/python/django/transit_indicators/urls.py
+++ b/python/django/transit_indicators/urls.py
@@ -34,7 +34,8 @@ urlpatterns = patterns('',  # NOQA
     url(r'^api/indicator-types/', 'transit_indicators.views.indicator_types'),
     url(r'^api/indicator-aggregation-types/', 'transit_indicators.views.indicator_aggregation_types'),
     url(r'^api/indicator-cities/', 'transit_indicators.views.indicator_cities'),
+    url(r'^api/city-name/', 'transit_indicators.views.city_name'),
     url(r'^api/sample-period-types/', 'transit_indicators.views.sample_period_types'),
     url(r'^api/gtfs-route-types/', 'transit_indicators.views.gtfs_route_types'),
-    url(r'^api/upload-statuses/', 'datasources.views.upload_status_choices'),
+    url(r'^api/upload-statuses/', 'datasources.views.upload_status_choices')
 )


### PR DESCRIPTION
This adds a dialog to the GTFS upload page where the user may change the name for their city; if no name has been set yet, it defaults to the value from Django settings.
There's now an endpoint at `api/city-name` that returns the user's city, which is used by the indicator calculation page to set the city name for indicator job runs, and to fetch the latest indicator version for the user's city.

![image](https://cloud.githubusercontent.com/assets/960264/4773168/509f98e6-5b9f-11e4-812f-2f800ce1be1e.png)
