### PR TITLE
Speed up Django/Scala communication to reduce timeouts

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -11,3 +11,4 @@ django-filter==0.7
 nose==1.3.1
 pylint==1.1.0
 django_nose==1.2
+gevent==1.0.1

--- a/python/django/transit_indicators/serializers.py
+++ b/python/django/transit_indicators/serializers.py
@@ -119,12 +119,6 @@ class IndicatorSerializer(serializers.ModelSerializer):
             if 'route_type' not in attrs:
                 raise serializers.ValidationError('Mode aggregation requires route_type')
 
-        # Convert the geometry from geojson to GEOS format for db insertion.
-        # This may not be the most correct place to perform this conversion,
-        # but it is by far the quickest/simplest.
-        if attrs.get("the_geom"):
-            attrs["the_geom"] = GEOSGeometry(json.dumps(attrs.get("the_geom")))
-
         return attrs
 
     class Meta:

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/OverallSystemIndicatorResult.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/OverallSystemIndicatorResult.scala
@@ -15,18 +15,18 @@ object OverallIndicatorResult {
 
     val containersByRoute: Iterable[ContainerGenerator] =
       byRoute.map { case (route, value) =>
-        OverallIndicatorResult(name, value).forRoute(route, geometries.byRouteGeoJson(route))
+        OverallIndicatorResult(name, value).forRoute(route, geometries.byRouteWkb(route))
       }
 
     val containersByRouteType: Iterable[ContainerGenerator] =
       byRouteType.map { case (routeType, value) =>
-        OverallIndicatorResult(name, value).forRouteType(routeType, geometries.byRouteTypeGeoJson(routeType))
+        OverallIndicatorResult(name, value).forRouteType(routeType, geometries.byRouteTypeWkb(routeType))
       }
 
     val containerForSystem: Seq[ContainerGenerator] =
       bySystem match {
         case Some(v) =>
-          Seq(OverallIndicatorResult(name, v).forSystem(geometries.bySystemGeoJson))
+          Seq(OverallIndicatorResult(name, v).forSystem(geometries.bySystemWkb))
         case None =>
           Seq()
       }

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/PeriodIndicatorResult.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/PeriodIndicatorResult.scala
@@ -16,19 +16,19 @@ object PeriodIndicatorResult {
     val containersByRoute: Iterable[ContainerGenerator] =
       byRoute.map { case (route, value) =>
         PeriodIndicatorResult(name, period, value)
-          .forRoute(route, geometries.byRouteGeoJson(route))
+          .forRoute(route, geometries.byRouteWkb(route))
       }
 
 
     val containersByRouteType: Iterable[ContainerGenerator] =
       byRouteType.map { case (routeType, value) =>
-        PeriodIndicatorResult(name, period, value).forRouteType(routeType, geometries.byRouteTypeGeoJson(routeType))
+        PeriodIndicatorResult(name, period, value).forRouteType(routeType, geometries.byRouteTypeWkb(routeType))
       }
 
     val containerForSystem: Iterable[ContainerGenerator] =
       bySystem match {
         case Some(v) =>
-          Seq(PeriodIndicatorResult(name, period, v).forSystem(geometries.bySystemGeoJson))
+          Seq(PeriodIndicatorResult(name, period, v).forSystem(geometries.bySystemWkb))
         case None =>
           Seq()
       }


### PR DESCRIPTION
This implements a variety of changes in an attempt to fix the timeout issue:
- Switch to gevent
- Increase workers and max requests for Gunicorn
- Increase all Spray client timeout settings
- Set niceness for the Scala process in order to give precedence to Gunicorn
- Switch to Well Known Binary to cut down on request size and parsing time
- Add sleeps to throttle requests from Scala to Django

With all of these changes implemented, I was able to have indicators calculated for Zhangzhou without seeing timeouts. However it's cutting it a little close -- if I reduce the sleeps, the timeouts come back. Ideally no sleeps would be needed. If anyone has any good ideas for things I missed, please pull down this branch, comment out the sleeps and give it a try.
