### PR TITLE
Default sample period to second available date in range.

### DIFF
--- a/js/angular/app/scripts/modules/settings/configuration/configuration-controller.js
+++ b/js/angular/app/scripts/modules/settings/configuration/configuration-controller.js
@@ -352,9 +352,10 @@ angular.module('transitIndicators')
             $scope.serviceEnd = OTIConfigurationService.createDateFromISO(serviceDates.end);
             var nextDay = null;
             
-            // if dates have not been chosen yet, default to first valid date in range
+            // if dates have not been chosen yet, default to second valid date in range
             if (!$scope.weekdayDate) {
                 nextDay = new Date($scope.serviceStart);
+                nextDay.setDate(nextDay.getDate() + 1);
                 while (!OTIConfigurationService.isWeekday(nextDay)) {
                   nextDay.setDate(nextDay.getDate() + 1);
                 }
@@ -363,6 +364,7 @@ angular.module('transitIndicators')
             
             if (!$scope.weekendDate) {
                 nextDay = new Date($scope.serviceStart);
+                nextDay.setDate(nextDay.getDate() + 1);
                 while (!OTIConfigurationService.isWeekend(nextDay)) {
                   nextDay.setDate(nextDay.getDate() + 1);
                 }


### PR DESCRIPTION
This is to avoid potential timezone issues if user is in different timezone than the GTFS.
Closes #387.
