### PR TITLE
Fix datepicker broken by update to Angular 1.3

### DIFF
--- a/js/angular/app/scripts/modules/settings/configuration/configuration-controller.js
+++ b/js/angular/app/scripts/modules/settings/configuration/configuration-controller.js
@@ -8,7 +8,7 @@ angular.module('transitIndicators')
     // Datepicker Options
     $scope.datepickerFormat = 'dd MMMM yyyy';
     $scope.dateOptions = {
-        startingDay: 1,
+        startingDay: 0,
         showWeeks: false
     };
 
@@ -179,8 +179,9 @@ angular.module('transitIndicators')
         $scope.morningPeakEnd = morningEnd.getHours();
         $scope.eveningPeakStart = eveningStart.getHours();
         $scope.eveningPeakEnd = eveningEnd.getHours();
-        $scope.weekdayDate = morningStart;
-        $scope.weekendDate = weekendStart;
+
+        $scope.weekdayDate = morningStart.toISOString();
+        $scope.weekendDate = weekendStart.toISOString();
     };
 
     var setSidebarCheckmark = function () {
@@ -218,8 +219,8 @@ angular.module('transitIndicators')
         $scope.samplePeriodsError = false;
         var promises = [];
 
-        var weekdayDate = $scope.weekdayDate;
-        var weekendDate = $scope.weekendDate;
+        var weekdayDate = new Date($scope.weekdayDate);
+        var weekendDate = new Date($scope.weekendDate);
 
         var morning = $scope.samplePeriods.morning;
         morning.period_start = createWeekdayDateTime(weekdayDate, $scope.morningPeakStart);
@@ -271,8 +272,12 @@ angular.module('transitIndicators')
      * Invalidate samplePeriodsForm if weekdayDate is not a weekday in service date range
      */
     $scope.validateWeekday = function () {
-        var isValid = OTIConfigurationService.isWeekday($scope.weekdayDate) && 
-                      isInServiceRange($scope.weekdayDate);
+        if (!$scope.weekdayDate) {
+            return;
+        }
+        var validateDay = new Date($scope.weekdayDate);
+        var isValid = OTIConfigurationService.isWeekday(validateDay) && 
+                      isInServiceRange(validateDay);
         $scope.samplePeriodsForm.weekdayDate.$setValidity('weekdayDate', isValid);
     };
 
@@ -280,8 +285,12 @@ angular.module('transitIndicators')
      * Invalidate samplePeriodsForm if weekendDate is not a weekend in service date range
      */
     $scope.validateWeekend = function () {
-        var isValid = OTIConfigurationService.isWeekend($scope.weekendDate) &&
-                      isInServiceRange($scope.weekendDate);
+        if (!$scope.weekendDate) {
+            return;
+        }
+        var validateDay = new Date($scope.weekendDate);
+        var isValid = OTIConfigurationService.isWeekend(validateDay) &&
+                      isInServiceRange(validateDay);
         $scope.samplePeriodsForm.weekendDate.$setValidity('weekendDate', isValid);
     };
     
@@ -290,6 +299,7 @@ angular.module('transitIndicators')
      */
     var isInServiceRange = function (date) {
         if (!$scope.serviceStart || !$scope.serviceEnd) {
+            console.log("missing service start and/or end!");
             return true;
         }
         

--- a/js/angular/app/scripts/modules/settings/configuration/configuration-partial.html
+++ b/js/angular/app/scripts/modules/settings/configuration/configuration-partial.html
@@ -23,7 +23,7 @@
                 <input type="text" class="form-control" datepicker-popup="{{datepickerFormat}}"
                        ng-model="weekdayDate" is-open="weekdayPickerOpen" show-weeks="false"
                        datepicker-options="dateOptions" ng-required="true" close-text="Close"
-                       min="serviceStart" max="serviceEnd" init-date="{{Date.now()}}"
+                       min-date="serviceStart" max-date="serviceEnd" init-date="{{Date.now()}}"
                        date-disabled="disableWeekend(date, mode)" name="weekdayDate"
                        ng-change="validateWeekday()" />
                 <span class="input-group-btn">
@@ -44,7 +44,7 @@
                 <input type="text" class="form-control" datepicker-popup="{{datepickerFormat}}"
                        ng-model="weekendDate" is-open="weekendPickerOpen" show-weeks="false"
                        datepicker-options="dateOptions" ng-required="true" close-text="Close"
-                       min="serviceStart" max="serviceEnd" date-disabled="disableWeekday(date, mode)"
+                       min-date="serviceStart" max-date="serviceEnd" date-disabled="disableWeekday(date, mode)"
                        name="weekendDate" ng-change="validateWeekend()" init-date="{{Date.now()}}" />
                 <span class="input-group-btn">
                     <button type="button" class="btn btn-default"

--- a/js/angular/bower.json
+++ b/js/angular/bower.json
@@ -28,7 +28,7 @@
     "angular-translate": "2.2.0",
     "angular-translate-loader-static-files": "2.2.0",
     "angular-translate-handler-log": "2.0.1",
-    "angular-bootstrap": "0.10.0",
+    "angular-bootstrap": "0.11.2",
     "angular-ui-utils": "0.1.1",
     "underscore": "1.6.0",
     "bootstrap-sass-official": "3.1.1+1",


### PR DESCRIPTION
-  Update Angular Bootstrap
-  Fix to start week in datepicker popup at Sunday and not Monday
-  Send string for date display, and save as Date object (Date object in display also shows time part and time zone)
-  Fix validation being called with undefined date
-  Fixes renamed allowed range min/max settings

There are a number of open issues around the datepicker in Angular 1.3 against angular-ui, but this seems to get things working again for our use of it.
