### PR TITLE
Alter previous migration - drop DB and reprovision to apply change

### DIFF
--- a/python/django/transit_indicators/migrations/0040_migrate_version_data.py
+++ b/python/django/transit_indicators/migrations/0040_migrate_version_data.py
@@ -29,14 +29,23 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             uuid_to_id
         ),
-        migrations.RemoveField(
+        migrations.AlterField(
             model_name='indicator',
-            name='version',
+            name='type',
+            field=models.CharField(max_length=32, choices=[(b'access_index', 'Access index'), (b'affordability', 'Affordability'), (b'avg_service_freq', 'Average Service Frequency'), (b'coverage_ratio_stops_buffer', 'Coverage of transit stops'), (b'distance_stops', 'Distance between stops'), (b'dwell_time', 'Dwell Time Performance'), (b'hours_service', 'Weekly number of hours of service'), (b'job_access', 'Job accessibility'), (b'length', 'Transit system length'), (b'lines_roads', 'Ratio of transit lines length over road length'), (b'line_network_density', 'Transit line network density'), (b'num_modes', 'Number of modes'), (b'num_routes', 'Number of routes'), (b'num_stops', 'Number of stops'), (b'num_types', 'Number of route types'), (b'on_time_perf', 'On-Time Performance'), (b'regularity_headways', 'Regularity of Headways'), (b'service_freq_weighted', 'Service frequency weighted by served population'), (b'service_freq_weighted_low', 'Service frequency weighted by served low-income population'), (b'stops_route_length', 'Ratio of number of stops to route-length'), (b'ratio_suburban_lines', 'Ratio of the Transit-Pattern Operating Suburban Lines'), (b'system_access', 'System accessibility'), (b'system_access_low', 'System accessibility - low-income'), (b'time_traveled_stops', 'Time traveled between stops'), (b'travel_time', 'Travel Time Performance'), (b'weekday_end_freq', 'Weekday / weekend frequency')]),
         ),
         migrations.AddField(
             model_name='indicator',
             name='calculation_job',
             field=models.ForeignKey(to='transit_indicators.IndicatorJob')
+        ),
+        migrations.AlterUniqueTogether(
+            name='indicator',
+            unique_together=set([('sample_period', 'type', 'aggregation', 'route_id', 'route_type', 'calculation_job')]),
+        ),
+        migrations.RemoveField(
+            model_name='indicator',
+            name='version',
         ),
         migrations.RunPython(
             copy_column


### PR DESCRIPTION
This change is annoying but migrations is confused about the non-existence of a field which uniqueness depends upon. This change fixes it but requires dropping DB and reprovisioning.

For your convenience, these commands will drop the DB:
update pg_database set datallowconn = 'false' where datname = 'transit_indicators';
SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE datname = 'transit_indicators';
drop DATABASE transit_indicators ;
