### PR TITLE
Closes #402: Close yes/no modal when navigating

### DIFF
--- a/js/angular/app/scripts/modules/indicators/data-controller.js
+++ b/js/angular/app/scripts/modules/indicators/data-controller.js
@@ -33,7 +33,8 @@ angular.module('transitIndicators')
                 };
                 OTIIndicatorsService.query('GET', params).then(function (data) {
                     // If there is no indicator data, ask to redirect to the calculation status page
-                    if (!data.length) {
+                    // only if we're still on the data page
+                    if (!data.length && $state.is('data') && !OTIIndicatorsService.isModalOpen()) {
                         $modal.open({
                             templateUrl: 'scripts/modules/indicators/yes-no-modal-partial.html',
                             controller: 'OTIYesNoModalController',

--- a/js/angular/app/scripts/modules/indicators/indicators-controller.js
+++ b/js/angular/app/scripts/modules/indicators/indicators-controller.js
@@ -42,7 +42,8 @@ angular.module('transitIndicators')
 
     $scope.openCityModal = function () {
         var modalCities = $scope.cities;
-        var modalInstance = $modal.open({
+        OTIIndicatorsService.setModalStatus(true);
+        var cityModalInstance = $modal.open({
             templateUrl: 'scripts/modules/indicators/city-modal-partial.html',
             controller: 'OTICityModalController',
             size: 'sm',
@@ -60,6 +61,8 @@ angular.module('transitIndicators')
                     return [];
                 }
             }
+        }).result.finally(function () {
+            OTIIndicatorsService.setModalStatus(false);
         });
     };
 

--- a/js/angular/app/scripts/modules/indicators/indicators-service.js
+++ b/js/angular/app/scripts/modules/indicators/indicators-service.js
@@ -7,7 +7,16 @@ angular.module('transitIndicators')
 
     var otiIndicatorsService = {};
     var nullJob = 0;
+    var modalStatus = false;
     otiIndicatorsService.selfCityName = null;
+
+    otiIndicatorsService.setModalStatus = function (isOpen) {
+        modalStatus = isOpen;
+    };
+
+    otiIndicatorsService.isModalOpen = function () {
+        return modalStatus;
+    };
 
     otiIndicatorsService.Indicator = $resource('/api/indicators/:id/', {id: '@id'}, {
         'update': {


### PR DESCRIPTION
Clears the modal display conflicts by:
1. Closing the yes/no modal if the page changes
before the modal has a chance to display
2. Do not display the yes/no modal when the add/remove
city modal is open.
