### PR TITLE
Delete scenario db on Scenario model deletion

### DIFF
--- a/python/django/transit_indicators/__init__.py
+++ b/python/django/transit_indicators/__init__.py
@@ -1,3 +1,5 @@
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from celery_settings import app as celery_app
+
+default_app_config = 'transit_indicators.apps.TransitIndicatorsAppConfig'

--- a/python/django/transit_indicators/apps.py
+++ b/python/django/transit_indicators/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class TransitIndicatorsAppConfig(AppConfig):
+    name = 'transit_indicators'
+    verbose_name = 'Open Transit Indicators'
+
+    def ready(self):
+        import signals  # NOQA

--- a/python/django/transit_indicators/signals.py
+++ b/python/django/transit_indicators/signals.py
@@ -1,0 +1,12 @@
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+from transit_indicators.tasks import start_scenario_deletion
+
+
+@receiver(post_delete, sender='transit_indicators.Scenario')
+def delete_scenario_db(sender, **kwargs):
+    """Delete a scenario's database when that scenario is deleted"""
+    scenario = kwargs.get('instance', None)
+    if scenario:
+        start_scenario_deletion.apply_async(args=[scenario.db_name], queue='scenarios')

--- a/python/django/transit_indicators/tasks/__init__.py
+++ b/python/django/transit_indicators/tasks/__init__.py
@@ -1,10 +1,12 @@
 from transit_indicators.models import IndicatorJob, Scenario
 from transit_indicators.tasks.calculate_indicators import run_indicator_calculation
 from transit_indicators.tasks.create_scenario import run_scenario_creation
+from transit_indicators.tasks.delete_scenario import run_scenario_deletion
 from transit_indicators.celery_settings import app
 
 from celery.utils.log import get_task_logger
 logger = get_task_logger(__name__)
+
 
 @app.task(bind=True, max_retries=3)
 def start_indicator_calculation(self, indicator_job_id):
@@ -18,6 +20,7 @@ def start_indicator_calculation(self, indicator_job_id):
         indicator_job.save()
         raise self.retry(exc=e)
 
+
 @app.task(bind=True, max_retries=3)
 def start_scenario_creation(self, scenario_id):
     try:
@@ -26,4 +29,12 @@ def start_scenario_creation(self, scenario_id):
     except Exception as e:
         Scenario.objects.get(pk=scenario_id).job_status = Scenario.StatusChoices.ERROR
         scenario.save()
+        raise self.retry(exc=e)
+
+
+@app.task(bind=True, max_retries=3)
+def start_scenario_deletion(self, db_name):
+    try:
+        run_scenario_deletion(db_name)
+    except Exception as e:
         raise self.retry(exc=e)

--- a/python/django/transit_indicators/tasks/delete_scenario.py
+++ b/python/django/transit_indicators/tasks/delete_scenario.py
@@ -1,0 +1,11 @@
+from celery.utils.log import get_task_logger
+from django.db import connection
+
+logger = get_task_logger(__name__)
+
+
+def run_scenario_deletion(db_name):
+    """Deletes the database associated with a scenario."""
+    logger.debug('Deleting database for scenario %s.', db_name)
+    cursor = connection.cursor()
+    cursor.execute('DROP DATABASE IF EXISTS "%s";', (db_name,))


### PR DESCRIPTION
Uses a Celery job to delete a Scenario's associated database when the
Scenario object is deleted. Triggers off the Django pre_delete signal so
that the database is deleted even when deleting objects via a batch
process which skips the model's delete() function.

Most of this is just getting the signal handler wired up.
