### PR TITLE
Remove Django-nose from requirements.txt

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -8,7 +8,5 @@ requests==2.2.1
 celery==3.1.10
 django-extensions==1.3
 django-filter==0.7
-nose==1.3.1
 pylint==1.1.0
-django_nose==1.2
 gevent==1.0.1


### PR DESCRIPTION
It doesn't seem to be used anywhere, and as far as I know, Django-Nose does not yet support Django 1.7
