### PR TITLE
Sort arrivals in headway regularity indicator

### DIFF
--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/HeadwayRegularitySpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/HeadwayRegularitySpec.scala
@@ -20,16 +20,15 @@ class HeadwayRegularitySpec
 
   val observedMapping = new ObservedStopTimeSpecParams {}
 
-  // Noise with a mean value of 7.5 minutes was introduced to create this simulated
-  // observational data - the slight difference from that result which we expect see here
-  // is likely due to the somewhat small sample size (none of the routes have more than 75
-  // samples)
-  //
-  // TODO: fix this test. After the recent geometry changes, the test returns 1.33256
-  ignore should "calculate the regularity of headway for SEPTA" in {
+  // The observed data was created by randomly increasing the arrival and departure times
+  // for each stop by up to 15 minutes (mean of 7.5 minutes). This would not be expected to
+  // change the average headway (time between arrivals), since all arrivals are shifted in
+  // the same direction by the same amount on average. The actual value is roughly in line with
+  // these expectations.
+  it should "calculate the regularity of headway for SEPTA" in {
     val calculation = new HeadwayRegularity(observedMapping).calculation(period)
     val AggregatedResults(byRoute, byRouteType, bySystem) = calculation(system)
-    bySystem.get should be (7.11 +- 1e-1)
+    bySystem.get should be (0.6867 +- 1e-1)
   }
 
 }

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/HeadwayRegularity.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/HeadwayRegularity.scala
@@ -41,9 +41,11 @@ class HeadwayRegularity(params: ObservedStopTimes)
     val headways: Seq[Double] =
       trips.map { trip =>
         trip.schedule
-          .groupBy(_.stop.id).toMap
-      }.combineMaps
-        .flatMap { case (k, groupedStops) =>
+          .groupBy(_.stop.id)
+      }.combineMaps.mapValues(arrivals =>
+        arrivals.sortWith((a,b) =>
+          a.arrivalTime.compareTo(b.arrivalTime) < 0)
+      ).flatMap { case (k, groupedStops) =>
           groupedStops.zip(groupedStops.tail).map { case (a, b) =>
             Seconds.secondsBetween(a.arrivalTime, b.arrivalTime).getSeconds.toDouble
           }


### PR DESCRIPTION
Partially addresses #380 

Sorts the arrivals in the headway regularity indicator; without this,
the stop arrivals appear to be ordered arbitrarily, leading to problems
such as negative average headways.

Before fix, expected and observed headways for SEPTA rail from the failing test (in seconds):

```
(763.8461538461538,804.5877192982456)
(973.3684210526316,1226.2222222222222)
(823.7647058823529,952.0631578947368)
(620.6795580110497,786.873076923077)
(261.6949152542373,243.04929577464787)
(1254.6666666666667,1295.0576923076924)
(639.6610169491526,716.0268456375838)
(261.68674698795184,229.2604501607717)
(895.5,1049.12)
(419.54887218045116,378.3831168831169)
(141.42857142857142,141.264)
(-205.13513513513513,-174.9502487562189) <-- Negative average headway
(26.81564245810056,85.16190476190476)
```

After fix:

```
(1119.2307692307693,1135.2368421052631)
(1417.6842105263158,1395.138888888889)
(945.8823529411765,1007.2105263157895)
(1143.7734806629835,1242.6346153846155)
(1119.8305084745762,1152.6267605633802)
(1294.6666666666667,1311.8076923076924)
(967.1186440677966,1002.3355704697987)
(901.3775100401606,872.2154340836013)
(1290.9,1240.0)
(1241.954887218045,1305.8116883116884)
(1414.2857142857142,1461.808)
(1258.6756756756756,1215.676616915423)
(979.4245810055866,996.7523809523809)
```

Updates test to match new indicator output.
