### PR TITLE
Fix LengthSpec

### DIFF
--- a/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/LengthSpec.scala
+++ b/scala/opentransit-test/src/test/scala/com/azavea/opentransit/indicators/LengthSpec.scala
@@ -27,7 +27,7 @@ class AdHocLengthSpec extends AdHocSystemIndicatorSpec {
 
 // TODO: fix these tests. After the recent geometry changes, the results are all off.
 class LengthSpec extends FlatSpec with Matchers with IndicatorSpec {
-  ignore should "calculate length by route for SEPTA" in {
+  it should "calculate length by route for SEPTA" in {
     val calculation = Length.calculation(period)
     val AggregatedResults(byRoute, byRouteType, bySystem) = calculation(system)
     implicit val routeMap = byRoute
@@ -38,7 +38,7 @@ class LengthSpec extends FlatSpec with Matchers with IndicatorSpec {
     // the indicator calculations remain consistent.
     getResultByRouteId(byRoute, "AIR") should be ( 21.86907 +- 1e-5)
     getResultByRouteId(byRoute, "CHE") should be ( 22.47520 +- 1e-5)
-    getResultByRouteId(byRoute, "CHW") should be ( 23.38168 +- 1e-5)
+    getResultByRouteId(byRoute, "CHW") should be ( 17.77621 +- 1e-5)
     getResultByRouteId(byRoute, "CYN") should be ( 10.08848 +- 1e-5)
     getResultByRouteId(byRoute, "FOX") should be ( 14.58365 +- 1e-5)
     getResultByRouteId(byRoute, "LAN") should be ( 59.69138 +- 1e-5)
@@ -52,46 +52,46 @@ class LengthSpec extends FlatSpec with Matchers with IndicatorSpec {
 
   }
 
-  ignore should "calculate overall length by route for SEPTA" in {
+  it should "calculate overall length by route for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(Length)
     implicit val routeMap = byRoute
 
     getResultByRouteId(byRoute, "AIR") should be ( 20.95786 +- 1e-5)
-    getResultByRouteId(byRoute, "CHE") should be ( 21.53873 +- 1e-5)
-    getResultByRouteId(byRoute, "CHW") should be ( 22.40745 +- 1e-5)
+    getResultByRouteId(byRoute, "CHE") should be ( 19.73522 +- 1e-5)
+    getResultByRouteId(byRoute, "CHW") should be ( 19.07085 +- 1e-5)
     getResultByRouteId(byRoute, "CYN") should be ( 9.66813 +- 1e-5)
     getResultByRouteId(byRoute, "FOX") should be ( 13.97600 +- 1e-5)
-    getResultByRouteId(byRoute, "LAN") should be ( 57.20424 +- 1e-5)
-    getResultByRouteId(byRoute, "MED") should be ( 55.90896 +- 1e-5)
+    getResultByRouteId(byRoute, "LAN") should be ( 54.42701 +- 1e-5)
+    getResultByRouteId(byRoute, "MED") should be ( 48.70017 +- 1e-5)
     getResultByRouteId(byRoute, "NOR") should be ( 33.06265 +- 1e-5)
-    getResultByRouteId(byRoute, "PAO") should be ( 58.50689 +- 1e-5)
-    getResultByRouteId(byRoute, "TRE") should be (112.58619 +- 1e-5)
+    getResultByRouteId(byRoute, "PAO") should be ( 56.50100 +- 1e-5)
+    getResultByRouteId(byRoute, "TRE") should be (112.13954 +- 1e-5)
     getResultByRouteId(byRoute, "WAR") should be ( 43.41826 +- 1e-5)
     getResultByRouteId(byRoute, "WIL") should be (124.62844 +- 1e-5)
-    getResultByRouteId(byRoute, "WTR") should be ( 55.17171 +- 1e-5)
+    getResultByRouteId(byRoute, "WTR") should be ( 52.07998 +- 1e-5)
   }
 
-  ignore should "calculate length by mode for SEPTA" in {
+  it should "calculate length by mode for SEPTA" in {
     val calculation = Length.calculation(period)
     val AggregatedResults(byRoute, byRouteType, bySystem) = calculation(system)
 
-    byRouteType(Rail) should be (656.38489 +- 1e-5)
+    byRouteType(Rail) should be (650.77942 +- 1e-5)
   }
 
-  ignore should "calculate overall length by mode for SEPTA" in {
+  it should "calculate overall length by mode for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(Length)
 
-    byRouteType(Rail) should be (629.03553 +- 1e-5)
+    byRouteType(Rail) should be (608.36514 +- 1e-5)
   }
 
-  ignore should "calculate length by system for SEPTA" in {
+  it should "calculate length by system for SEPTA" in {
     val calculation = Length.calculation(period)
     val AggregatedResults(byRoute, byRouteType, bySystem) = calculation(system)
-    bySystem.get should be (656.38489 +- 1e-5)
+    bySystem.get should be (650.77942 +- 1e-5)
   }
 
-  ignore should "calculate overall length by system for SEPTA" in {
+  it should "calculate overall length by system for SEPTA" in {
     val AggregatedResults(byRoute, byRouteType, bySystem) = septaOverall(Length)
-    bySystem.get should be (629.03553 +- 1e-5)
+    bySystem.get should be (608.36514 +- 1e-5)
   }
 }


### PR DESCRIPTION
This isn't so much a fix as changing the expected values to match what
is occurring. As best we can tell, the current test was written at a
point when ScheduledStops were not being filtered out of TransitSystems
if they fell outside of the SamplePeriod for a given indicator
calculation. Manually disabling the stop filtering fixes the LengthSpec,
but is not expected behavior and causes many other tests to fail.

It appears that the LengthSpec was broken by adding / fixing the stops
pruning functionality, but that in all the confusion around the
refactor, it was missed until later when we thought it was due to the
geometry changes. The indicator has been manually verified to be working
correctly using QGIS, so these values should be correct. If they're not,
then it's most likely a problem relating to how transit systems are
constructed, rather than a problem with the Length indicator.
