### PR TITLE
Better race condition ordering

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/CalculateIndicators.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/CalculateIndicators.scala
@@ -235,8 +235,6 @@ object CalculateIndicators {
       }
     }
 
-    runWeeklySvcHours(periods, builder, overallLineGeoms, statusManager, calculateAllTime, trackStatus)
-
     resultHolder.map { case (indicatorName, periodToResults) =>
       val periodIndicatorResults: Seq[ContainerGenerator] =
         periodToResults.map { case (period, result) =>
@@ -275,6 +273,9 @@ object CalculateIndicators {
       }
     }
     System.gc()
+
+    runWeeklySvcHours(periods, builder, overallLineGeoms, statusManager, calculateAllTime, trackStatus)
+
   }
 
   /** Computes all indicators, and sends results and intermediate statuses to the


### PR DESCRIPTION
This very small change doesn't fix a race condition that apparently causes status indicators to be posted to DB by django slightly out of the expected order, but it does make that race far more predictable.

Because trackstatus pushes to django after every indicator's successful calculation, it is possible that the last and second to last calculation will be sent to django at almost exactly the same time. Django, running with multiple workers, will then non-deterministically apply changes to DB, potentially messing up the ordering that we would normally expect.

By shifting weekly service hours to the very end of the calculation chain, we are effectively putting ~10 seconds between the second to last and the last post to django. This ought to prevent the status-limbo that the race condition makes possible.
