### PR TITLE
Fix to jobs indicator reprojection & calculation.

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/CalculateIndicators.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/CalculateIndicators.scala
@@ -92,7 +92,7 @@ object CalculateIndicators {
           periods,
           builder,
           100,  // TODO: How do we decide on the resolution?
-          request.arriveByTime - request.maxCommuteTime,
+          request.arriveByTime,
           request.maxCommuteTime
         )
       } match {
@@ -186,7 +186,7 @@ object CalculateIndicators {
           )
         else mutable.Map()
 
-      val status = mutable.Map[String, mutable.Map[String, JobStatus]]() ++
+      val status = mutable.Map[String, mutable.Map[String, JobStatus]]() ++ 
         periods.map { period =>
           period.periodType ->
             mutable.Map(
@@ -194,7 +194,7 @@ object CalculateIndicators {
                 name -> JobStatus.Submitted
               }: _* // This construct is stupid. It is also the correct syntax for making this kind of map
             )
-        } ++ travelshedStatus ++ weeklyHoursStatus ++ allTimeAggregationStatus
+        } ++ travelshedStatus ++ weeklyHoursStatus ++ allTimeAggregationStatus 
 
 
       def sendStatus = statusManager.statusChanged(status.map { case (k, v) => k -> v.toMap }.toMap)

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/TravelshedGraph.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/TravelshedGraph.scala
@@ -22,7 +22,7 @@ import scala.slick.jdbc.JdbcBackend.{Database, DatabaseDef, Session}
 import com.typesafe.config.ConfigFactory
 
 
-case class TravelshedGraph(graph: TransitGraph, index: SpatialIndex[Int], rasterExtent: RasterExtent, startTime: Int, duration: Int, crs: CRS)
+case class TravelshedGraph(graph: TransitGraph, index: SpatialIndex[Int], rasterExtent: RasterExtent, arriveTime: Int, duration: Int, crs: CRS)
 
 object TravelshedGraph extends Logging {
   def findTransform(transitSystem: TransitSystem): CRS = {
@@ -47,12 +47,12 @@ object TravelshedGraph extends Logging {
     periods: Seq[SamplePeriod],
     builder: TransitSystemBuilder,
     resolution: Double,
-    startTime: Int,
+    arriveTime: Int,
     duration: Int
   )( implicit session: Session): Option[TravelshedGraph] = {
     SamplePeriod.getRepresentativeWeekday(periods).map { weekday =>
-      val startDateTime = weekday.toLocalDateTime(new LocalTime(0,0).plusSeconds(startTime - 1))
-      val endDateTime = weekday.toLocalDateTime(new LocalTime(0,0).plusSeconds(startTime + duration + 1))
+      val startDateTime = weekday.toLocalDateTime(new LocalTime(0,0).plusSeconds(arriveTime - duration - 1))
+      val endDateTime = weekday.toLocalDateTime(new LocalTime(0,0).plusSeconds(arriveTime + 1))
       info(s"Building system...")
       val system =
         builder.systemBetween(startDateTime, endDateTime)
@@ -177,7 +177,7 @@ object TravelshedGraph extends Logging {
             }
           }
 
-        TravelshedGraph(graph, index, rasterExtent, startTime, duration, crs)
+        TravelshedGraph(graph, index, rasterExtent, arriveTime, duration, crs)
       }
     }
   }

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/travelshed/JobsTravelshedIndicator.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/travelshed/JobsTravelshedIndicator.scala
@@ -32,16 +32,16 @@ class JobsTravelshedIndicator(travelshedGraph: TravelshedGraph, regionDemographi
   def name = JobsTravelshedIndicator.name
 
   def apply(rasterCache: RasterCache): Unit = {
-    val (graph, index, rasterExtent, startTime, duration, crs) = {
+    val (graph, index, rasterExtent, arriveTime, duration, crs) = {
       val tg = travelshedGraph
 
-      val startTime: Time = Time(tg.startTime)
+      val arriveTime: Time = Time(tg.arriveTime)
       val duration: Duration = Duration(tg.duration)
 
-      (tg.graph, tg.index, tg.rasterExtent, startTime, duration, tg.crs)
+      (tg.graph, tg.index, tg.rasterExtent, arriveTime, duration, tg.crs)
     }
 
-    println(s"RUNNING JOB INDICATORS FOR START TIME $startTime WITH $duration TRAVEL TIME")
+    println(s"RUNNING JOB INDICATORS FOR ARRIVAL TIME $arriveTime WITH $duration TRAVEL TIME")
 
     val features: Array[MultiPolygonFeature[Double]] =
       regionDemographics.jobsDemographics.toArray
@@ -111,16 +111,16 @@ class JobsTravelshedIndicator(travelshedGraph: TravelshedGraph, regionDemographi
 
             val queue = new IntPriorityQueue(shortestPathTimes)
 
-            val tripStart = startTime.toInt
-            val duration = tripStart + maxDuration
+            val tripEnd = arriveTime.toInt
+            val duration = tripEnd - maxDuration
 
             val edgeIterator =
               graph.getEdgeIterator(edgeTypes, EdgeDirection.Outgoing)
 
 
-            edgeIterator.foreachEdge(startVertex,tripStart) { (target,weight) =>
-              val t = tripStart + weight
-              if(t <= duration) {
+            edgeIterator.foreachEdge(startVertex, tripEnd) { (target,weight) =>
+              val t = tripEnd - weight
+              if(t >= duration) {
                 shortestPathTimes(target) = t
                 queue += target
                 val polyId = vertexToPolyId(target)
@@ -136,10 +136,10 @@ class JobsTravelshedIndicator(travelshedGraph: TravelshedGraph, regionDemographi
               val currentVertexShortestPathTime = shortestPathTimes(currentVertex)
 
               edgeIterator.foreachEdge(currentVertex, currentVertexShortestPathTime) { (target, weight) =>
-                val t = currentVertexShortestPathTime + weight
-                if(t <= duration) {
+                val t = currentVertexShortestPathTime - weight
+                if(t >= duration) {
                   val timeAtTarget = shortestPathTimes(target)
-                  if(timeAtTarget == -1 || t < timeAtTarget) {
+                  if(timeAtTarget == -1 || timeAtTarget < t) {
                     val polyId = vertexToPolyId(target)
                     if(polyId != -1 && polyHits(polyId) != polyHit) {
                       sum += polyIdToValue(polyId)


### PR DESCRIPTION
Removed a warp call that was behaving funny and not actually doing any good. Not sure why the `Tile.warp(Extent, Extent)` call was not cropping and instead funking out the raster...I wrote a GeoTrellis ticket to look into that.

Also changed the jobs indicator to be a calculation of 'what sum of the population can get to a place by an arrival time in the amount of time specified in the duration', instead of 'what are the number of jobs that could be arrived at by the arrival time by someone leaving from an area and traveling for no more then the specified duration.'
