### PR TITLE
Add directive for exporting indicators as CSVs

### DIFF
--- a/js/angular/app/index.html
+++ b/js/angular/app/index.html
@@ -89,6 +89,7 @@
         <script src="scripts/config.js"></script>
         <script src="scripts/windshaft-config.js"></script>
         <script src="scripts/directives/polling-upload.js"></script>
+        <script src="scripts/directives/oti-csv-export.js"></script>
         <script src="scripts/directives/oti-legend.js"></script>
         <script src="scripts/directives/oti-mode-selector.js"></script>
         <script src="scripts/modules/events/oti-events.js"></script>

--- a/js/angular/app/scripts/directives/oti-csv-export.js
+++ b/js/angular/app/scripts/directives/oti-csv-export.js
@@ -1,0 +1,53 @@
+'use strict';
+/**
+Directive that allows a user to download indicator results as a CSV
+*/
+
+angular.module('transitIndicators')
+.directive('otiCsvExport', ['$document', '$window', 'OTIIndicatorModel',
+function ($document, $window, OTIIndicatorModel) {
+    var template = [
+        '<button ng-click="exportCsv()" type="button" ',
+        'class="btn btn-default btn-lg glyphicon glyphicon-save">',
+        '</button>'
+    ].join('');
+
+    return {
+        restrict: 'E',
+        scope: {
+            job: '='
+        },
+        template: template,
+        link: function (scope) {
+            /**
+             * Exports indicator results for a given job as a CSV and downloads to a user's machine
+             */
+            scope.exportCsv = function () {
+                var params = {
+                    calculation_job: scope.job.id,
+                    format: 'csv'
+                };
+                var cityName = scope.job.city_name.replace(/ /g, '_').toLowerCase();
+                var fileName = cityName + '_' + scope.job.id + '.csv';
+
+                OTIIndicatorModel.csv(params, function (data) {
+                    if (window.navigator.msSaveOrOpenBlob) {
+                        // IE doesn't support blob URL generation,
+                        // but it does have a special API for this
+                        window.navigator.msSaveOrOpenBlob(data.csv, fileName);
+                    } else {
+                        // For other browsers, create a temporary element
+                        // and simulate a click to download
+                        var element = angular.element('<a>');
+                        var url = $window.URL || $window.webkitURL;
+                        element.attr('href', url.createObjectURL(data.csv));
+                        element.attr('download', fileName);
+                        $document.find('body').append(element);
+                        element[0].click();
+                        element.remove();
+                    }
+                });
+            };
+        }
+    };
+}]);

--- a/js/angular/app/scripts/modules/indicator-services/indicator-model.js
+++ b/js/angular/app/scripts/modules/indicator-services/indicator-model.js
@@ -14,6 +14,21 @@ angular.module('transitIndicators')
             url: '/api/indicators/',
             isArray: true,
             cache: true
+        },
+        'csv': {
+            method: 'GET',
+            url: '/api/indicators/',
+            transformResponse: function(data) {
+                var csv;
+                if (data) {
+                    csv = new Blob([data], {
+                        type: 'application/csv'
+                    });
+                }
+                return {
+                    csv: csv
+                };
+            }
         }
     }, {
         stripTrailingSlashes: false

--- a/js/angular/app/scripts/modules/indicators/data-partial.html
+++ b/js/angular/app/scripts/modules/indicators/data-partial.html
@@ -13,12 +13,7 @@
         <div class="indicators-cell indicators-label">{{ 'CALCULATION.VIEWING_RESULTS' | translate }} <span ng-show="updating" class="label label-info">{{ 'TERM.UPDATING_INDICATORS' | translate }}</span></div>
         <div ng-repeat="city in cities" class="indicators-cell">
           {{ city.city_name }}
-          <a ng-href="/api/indicators/?format=csv&city_name={{ selfCityName }}"
-             download="{{ selfCityName }}.csv">
-            <button type="button" class="btn btn-default btn-lg glyphicon glyphicon-save"
-                    ng-if="cityname == selfCityName">
-            </button>
-          </a>
+          <oti-csv-export job="city"></oti-csv-export>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This adds back in the indicator export buttons and makes them
work even if a user isn't logged in to the API.

Closes #508
