### PR TITLE
Fix route instance destroyed on route-stops -> route-edit nav

### DIFF
--- a/js/angular/app/scripts/modules/scenarios/route-edit/route-edit-controller.js
+++ b/js/angular/app/scripts/modules/scenarios/route-edit/route-edit-controller.js
@@ -42,7 +42,7 @@ angular.module('transitIndicators')
             if ($scope.route.isNew) {
                 $scope.route.$create();
             } else {
-                $scope.route.$update();
+                OTIRouteManager.update($scope.route);
             }
             $state.go('route-stops');
         }

--- a/js/angular/app/scripts/modules/scenarios/route-manager.js
+++ b/js/angular/app/scripts/modules/scenarios/route-manager.js
@@ -28,6 +28,14 @@ angular.module('transitIndicators')
         route.db_name = scenario.db_name;
     };
 
+    module.update = function (route) {
+        var scenario = OTIScenarioManager.get();
+        OTIRouteModel.update({
+            db_name: scenario.db_name,
+            routeId: route.id
+        }, route);
+    };
+
     /**
      * For now, isNew is defined as the route not having an id
      * Could track this with an internal var instead


### PR DESCRIPTION
When a $resource instance method such as $update() is used,
the instance is resolved with the response from the server,
regardless of what that response is. So when scala API returns
text 'OK', our route object is destroyed. Quickfix is to use
the $resource class method instead.
