### PR TITLE
Set up buffered pruning of stops to allow a window beyond the sample period

### DIFF
--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/TransitSystemBuilder.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/TransitSystemBuilder.scala
@@ -70,7 +70,7 @@ class TransitSystemBuilder(records: GtfsRecords) {
   def systemBetween(
       start: LocalDateTime,
       end: LocalDateTime,
-      pruneStops: Boolean = true): TransitSystem = {
+      pruneStopsBufferMinutes: Int = 0): TransitSystem = {
     val dates = {
       val startDate = start.toLocalDate
       val endDate = end.toLocalDate
@@ -107,7 +107,7 @@ class TransitSystemBuilder(records: GtfsRecords) {
                   f(stopTimeRecords, date, stopIdToStop)
                     .map { stopList =>
                       stopList.filter { stop => // chop off stops that happen past our system bounds
-                        !pruneStops || (start <= stop.departureTime && stop.arrivalTime <= end)
+                        (start <= stop.departureTime + pruneStopsBufferMinutes.minute && stop.arrivalTime - pruneStopsBufferMinutes.minute <= end)
                       }
                     }
                     .filter (_.length > 0) // throw out empty stop lists after prune

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/ObservedStopTimes.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/ObservedStopTimes.scala
@@ -40,7 +40,9 @@ object ObservedStopTimes {
           }
         }
       val builder = TransitSystemBuilder(observedGtfsRecords)
-      builder.systemBetween(period.start, period.end, pruneStops=false)
+      // pruneStopsMinuteBuffer is an optional parameter (default=0) which specifies
+      // just how far a trip's stops can extend beyond the sampleperiod
+      builder.systemBetween(period.start, period.end, pruneStopsBufferMinutes=120)
     }
 
     lazy val observedTrips: Map[String, Trip] =
@@ -80,7 +82,7 @@ object ObservedStopTimes {
 
     if (hasObserved) {
       new ObservedStopTimes {
-        def observedStopsByTrip(tripId: String): Seq[(ScheduledStop, ScheduledStop)] = 
+        def observedStopsByTrip(tripId: String): Seq[(ScheduledStop, ScheduledStop)] =
           observedStops.get(tripId) match {
             case Some(s) => s
             case None => Nil


### PR DESCRIPTION
This change fixes the bizarre 'real-time' values that were previously seen

![screen shot 2014-12-04 at 12 44 55 pm](https://cloud.githubusercontent.com/assets/1977405/5302988/6431ad2a-7bb3-11e4-8eaa-3fcaa3bf646e.png)
