### PR TITLE
Fix accidental removal of negation

### DIFF
--- a/js/angular/app/scripts/app.js
+++ b/js/angular/app/scripts/app.js
@@ -198,7 +198,7 @@ angular.module('transitIndicators', [
                 $state.go('transit');
                 return;
             }
-            if (stateClean(to.name) && !authService.isAuthenticated()) {
+            if (!stateClean(to.name) && !authService.isAuthenticated()) {
                 event.preventDefault();
                 $state.go('login');
                 return;


### PR DESCRIPTION
This fixes the accidental removal of a negation which is necessary for the page to load if not already logged in. The bug was introduced here: 2d6c753eacd9507a174ba8d9e3f38318f7d15a21
