### PR TITLE
Set up demographics tile service

### DIFF
--- a/js/angular/app/i18n/en.json
+++ b/js/angular/app/i18n/en.json
@@ -309,6 +309,7 @@
         "POPULATION": "Population",
         "POPULATION_METRIC_ONE": "Population Metric 1:",
         "POPULATION_METRIC_TWO": "Population Metric 2:",
+        "DESTINATION": "Destination",
         "DEMOGRAPHIC_METRIC": "Destination Metric:",
         "OVERVIEW_DESCRIPTION": "Welcome to the Open Transit Indicators application. This section allows administrators to configure the application so that it can calculate a variety of performance and accessibility metrics.",
         "OVERVIEW_REQUIRED_HEADER": "Required Inputs",

--- a/js/angular/app/i18n/es.json
+++ b/js/angular/app/i18n/es.json
@@ -308,6 +308,7 @@
         "POPULATION": "!Population",
         "POPULATION_METRIC_ONE": "!Population Metric 1:",
         "POPULATION_METRIC_TWO": "!Population Metric 2:",
+        "DESTINATION": "!Destination",
         "DEMOGRAPHIC_METRIC": "!Demographic Metric:",
         "OVERVIEW_DESCRIPTION": "Welcome to the Open Transit Indicators application. This section allows administrators to configure the application so that it can calculate a variety of performance and accessibility metrics.",
         "OVERVIEW_REQUIRED_HEADER": "Required Inputs",

--- a/js/angular/app/i18n/vi.json
+++ b/js/angular/app/i18n/vi.json
@@ -308,6 +308,7 @@
         "POPULATION": "Dân cư",
         "POPULATION_METRIC_ONE": "Số liệu thống kê dân cư 1:",
         "POPULATION_METRIC_TWO": "Số liệu thống kê dân cư 2:",
+        "DESTINATION": "!Destination",
         "DEMOGRAPHIC_METRIC": "Dữ liệu thống kê nhân khẩu:",
         "OVERVIEW_DESCRIPTION": "Welcome to the Open Transit Indicators application. This section allows administrators to configure the application so that it can calculate a variety of performance and accessibility metrics.",
         "OVERVIEW_REQUIRED_HEADER": "Required Inputs",

--- a/js/angular/app/i18n/zh.json
+++ b/js/angular/app/i18n/zh.json
@@ -308,6 +308,7 @@
         "POPULATION": "人口",
         "POPULATION_METRIC_ONE": "人口度量指标1：",
         "POPULATION_METRIC_TWO": "人口度量指标2：",
+        "DESTINATION": "!Destination",
         "DEMOGRAPHIC_METRIC": "人口统计度量指标：",
         "OVERVIEW_DESCRIPTION": "欢迎来到开放公交指标应用程序。管理员可以在这个模块进行参数设置来进行各种可达性以及服务水平的指标计算。",
         "OVERVIEW_REQUIRED_HEADER": "必选的输入",

--- a/js/angular/app/scripts/modules/settings/demographic/demographic-partial.html
+++ b/js/angular/app/scripts/modules/settings/demographic/demographic-partial.html
@@ -55,7 +55,7 @@
                 </div>
             <div class="col-sm-4"></div>
         </div>
-        <h4>{{'VIEW.DEMOGRAPHIC' | translate}}</h4>
+        <h4>{{'SETTINGS.DESTINATION' | translate}}</h4>
         <div class="settingsmodal-fieldgroup">
             <div class="row">
                 <div class="col-sm-4">

--- a/js/windshaft/server.js
+++ b/js/windshaft/server.js
@@ -39,6 +39,12 @@ var config = {
             var datasourcesBoundary = new oti.datasourcesBoundary();
             req.params.sql = datasourcesBoundary.getSql();
             req.params.style = datasourcesBoundary.getStyle();
+        } else if (req.params.type === 'datasources_demographics') {
+            var metric = req.query.metric || 'population_metric_1';
+            var ntiles = req.query.ntiles || "5";
+            var datasourcesDemographics = new oti.DatasourcesDemographics(metric, ntiles);
+            req.params.sql = datasourcesDemographics.getSql();
+            req.params.style = datasourcesDemographics.getStyle();
         } else if (req.params.type === 'coverage_ratio_stops_buffer') {
             var gtfsStopsBuffers = new oti.GTFSStopsBuffers(req.params);
             req.params.sql = gtfsStopsBuffers.getSql();


### PR DESCRIPTION
Modifies Windshaft to serve demographic tiles with quintile divisions; the endpoint is `/tiles/transit_indicators/<calculation_job>/datasources_demographics/<period>/<type>/x/y/z.png?metric=<metric_type>`

This is roughly the same as the boundaries tiles endpoint, but with the addition of the `metric` parameter. `metric` can be one of:
- population_metric_1
- population_metric_2
- destination_metric_1

Anything else will cause an error to be thrown.
There is also an `ntiles` parameter, but the only acceptable value is currently the default, 5.

Examples (red = low, blue = high):
Philly population 2010
![philly_pop2010](https://cloud.githubusercontent.com/assets/447977/5599413/c6d449e6-9293-11e4-9102-8404319a61d9.png)
Philly African American population 2010
![philly_african_american](https://cloud.githubusercontent.com/assets/447977/5599414/c6e19b14-9293-11e4-98f6-505523160f99.png)
Philly jobs info
![philly_jobs](https://cloud.githubusercontent.com/assets/447977/5599415/c6e25234-9293-11e4-9a61-3a313ba6aea7.png)
