### PR TITLE
Update AMI to address glibc vulnerability

### DIFF
--- a/deployment/packer/open-transit-indicators.json
+++ b/deployment/packer/open-transit-indicators.json
@@ -3,7 +3,7 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "aws_region": "us-east-1",
-    "ubuntu_ami": "ami-daaed0b2",
+    "ubuntu_ami": "ami-fcbbff94",
     "oti_branch": "master",
     "instance_type": "m1.medium"
   },


### PR DESCRIPTION
Makes sure that the base AMI which Packer uses contains a patched version of glibc to address the so-called "Ghost" vulnerability. Trivial, merging immediately.