### PR TITLE
Display "plain" GTFS data on indicator map

### DIFF
--- a/js/angular/app/scripts/modules/indicators/map-controller.js
+++ b/js/angular/app/scripts/modules/indicators/map-controller.js
@@ -93,6 +93,37 @@ angular.module('transitIndicators')
             // When copied to the internal L.Utfgrid class, these options end up on
             //  layer.options, same as for TileLayers
             pluginOptions: angular.extend({ 'useJsonP': false }, $scope.indicator)
+        },
+        gtfs_shapes: {
+            name: $translate.instant('MAP.TRANSIT_ROUTES'),
+            type: 'xyz',
+            url: OTIMapService.gtfsShapesUrl(),
+            visible: false,
+            layerOptions: {
+                modes: OTIMapService.getTransitModes(),
+                scenario: OTIMapService.getScenario()
+            }
+        },
+        gtfs_stops: {
+            name: $translate.instant('MAP.TRANSIT_STOPS'),
+            type: 'xyz',
+            url: OTIMapService.gtfsStopsUrl('png'),
+            visible: true,
+            layerOptions: {
+                modes: OTIMapService.getTransitModes(),
+                scenario: OTIMapService.getScenario()
+            }
+        },
+        gtfs_stops_utfgrid: {
+            name: $translate.instant('MAP.TRANSIT_STOPS_INTERACTIVITY'),
+            type: 'utfGrid',
+            url: OTIMapService.gtfsStopsUrl('utfgrid'),
+            visible: false,
+            pluginOptions: {
+                'useJsonP': false,
+                modes: OTIMapService.getTransitModes(),
+                scenario: OTIMapService.getScenario()
+            }
         }
     };
     $scope.updateLeafletOverlays(overlays);


### PR DESCRIPTION
Routes and interactivity are hidden by default because they make it
difficult to use the indicator information.
![oti-gtfs-indicator-map](https://cloud.githubusercontent.com/assets/447977/7988209/356dce38-0ab0-11e5-8328-32161b3938d2.png)
