### PR TITLE
Feature/remove other cities from dropdown

### DIFF
--- a/js/angular/app/scripts/directives/oti-coverage-legend.js
+++ b/js/angular/app/scripts/directives/oti-coverage-legend.js
@@ -48,7 +48,7 @@ angular.module('transitIndicators')
             access2: '='
         },
         template: template,
-        link: function (scope) {
+        link: function () {
         }
     };
 }]);

--- a/js/angular/app/scripts/modules/indicators/map-controller.js
+++ b/js/angular/app/scripts/modules/indicators/map-controller.js
@@ -303,6 +303,15 @@ angular.module('transitIndicators')
             }
             $scope.selectCity($scope.selectedCity);
         }
+
+        // only show current city and its scenarios on map page drop-down
+        OTISettingsService.cityName.get({}, function (data) {
+            var cityName = data.city_name;
+            $scope.current_scenarios = _.filter($scope.cities, function(city) {
+                return (city.city_name === cityName || city.scenario !== null);
+            });
+        });
+
         updateIndicatorLegend($scope.indicator);
         OTIMapService.getLegendData();
 

--- a/js/angular/app/scripts/modules/indicators/map-partial.html
+++ b/js/angular/app/scripts/modules/indicators/map-partial.html
@@ -7,7 +7,7 @@
                     {{ selectedCity.city_name }} <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                    <li ng-repeat="city in cities">
+                    <li ng-repeat="city in current_scenarios">
                         <a ng-click="selectCity(city)"> {{ city.city_name }}</a>
                     </li>
                 </ul>


### PR DESCRIPTION
Not sure if anything else is supposed to happen with the card, but this removes the city selection dropdown from the indicator map page.

![image](https://cloud.githubusercontent.com/assets/960264/8014770/66060726-0ba1-11e5-9d92-007a143df759.png)
