### PR TITLE
Feature/clip demographics to region

### DIFF
--- a/deployment/clip_demographics.sql
+++ b/deployment/clip_demographics.sql
@@ -1,0 +1,30 @@
+-- Function to clip demographics features to region boundaries.
+-- Proportionally allocates values to remaining area of clipped feature.
+
+DROP FUNCTION IF EXISTS ClipDemographics();
+
+CREATE OR REPLACE FUNCTION ClipDemographics()
+  RETURNS void AS
+$$
+DECLARE
+  region geometry;
+  diff geometry;
+  min_feature_id int4;
+  max_feature_id int4;
+BEGIN
+  RAISE INFO 'Going to clip demographics to boundary';
+  region := geom FROM datasources_boundary WHERE id = (SELECT region_boundary_id FROM transit_indicators_otiindicatorsconfig);
+  min_feature_id := min(id) FROM datasources_demographicdatafeature;
+  max_feature_id := max(id) FROM datasources_demographicdatafeature;
+
+  FOR feat_id IN min_feature_id..max_feature_id Loop
+    diff := ST_Difference((SELECT geom from datasources_demographicdatafeature where id=feat_id), region);
+    IF (ST_isEmpty(diff) IS FALSE) THEN
+      RAISE WARNING 'Found demographics feature outside region boundary';
+    END IF;
+  END Loop;
+
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER FUNCTION ClipDemographics() OWNER TO transit_indicators;

--- a/deployment/clip_demographics.sql
+++ b/deployment/clip_demographics.sql
@@ -9,19 +9,44 @@ $$
 DECLARE
   region geometry;
   diff geometry;
+  intersection geometry;
   min_feature_id int4;
   max_feature_id int4;
+  feature_area NUMERIC;  -- in SRID units
+  intersection_area NUMERIC;
+  contained_proportion NUMERIC;
 BEGIN
-  RAISE INFO 'Going to clip demographics to boundary';
+  RAISE INFO 'Going to clip demographics features to region boundary.';
   region := geom FROM datasources_boundary WHERE id = (SELECT region_boundary_id FROM transit_indicators_otiindicatorsconfig);
   min_feature_id := min(id) FROM datasources_demographicdatafeature;
   max_feature_id := max(id) FROM datasources_demographicdatafeature;
 
   FOR feat_id IN min_feature_id..max_feature_id Loop
-    diff := ST_Difference((SELECT geom from datasources_demographicdatafeature where id=feat_id), region);
-    IF (ST_isEmpty(diff) IS FALSE) THEN
-      RAISE WARNING 'Found demographics feature outside region boundary';
+
+    -- find the portion of the feature, if any, not contained in the region
+    diff := ST_Difference((SELECT geom FROM datasources_demographicdatafeature WHERE id = feat_id), region);
+
+    IF (ST_IsEmpty(diff) IS FALSE) THEN
+      intersection := ST_Intersection((SELECT geom FROM datasources_demographicdatafeature WHERE id = feat_id), region);
+
+      IF (ST_IsEmpty(intersection) IS TRUE) THEN
+        RAISE INFO 'Deleting demographics feature % completely outside region.', feat_id;
+        DELETE FROM datasources_demographicdatafeature WHERE id=feat_id;
+      ELSE
+        -- set feature to clipped geom with proportionally allocated metric values by area
+        intersection_area := ST_Area(intersection);
+        feature_area := ST_Area(geom) FROM datasources_demographicdatafeature WHERE id = feat_id;
+        contained_proportion := intersection_area / feature_area;
+        RAISE INFO '% percent of area of demographics feature % is within region; clipping.', contained_proportion, feat_id;
+        UPDATE datasources_demographicdatafeature
+          SET geom = ST_Multi(intersection),
+            population_metric_1 = population_metric_1 * contained_proportion,
+            population_metric_2 = population_metric_2 * contained_proportion,
+            destination_metric_1 = destination_metric_1 * contained_proportion
+          WHERE id = feat_id;
+      END IF;
     END IF;
+
   END Loop;
 
 END;

--- a/deployment/clip_demographics.sql
+++ b/deployment/clip_demographics.sql
@@ -16,8 +16,21 @@ DECLARE
   intersection_area NUMERIC;
   contained_proportion NUMERIC;
 BEGIN
-  RAISE INFO 'Going to clip demographics features to region boundary.';
   region := geom FROM datasources_boundary WHERE id = (SELECT region_boundary_id FROM transit_indicators_otiindicatorsconfig);
+  IF (region IS NULL) THEN
+    -- check for city bounds instead
+    region := geom FROM datasources_boundary WHERE id = (SELECT city_boundary_id FROM transit_indicators_otiindicatorsconfig);
+    IF (region IS NULL) THEN
+      RAISE WARNING 'Found neither city nor region bounds to which to clip demographics.';
+      -- nothing to do; bail
+      RETURN;
+    ELSE
+      RAISE INFO 'Going to clip demographics features to city boundary (region boundary not found).';
+    END IF;
+  ELSE
+    RAISE INFO 'Going to clip demographics features to region boundary.';
+  END IF;
+
   min_feature_id := min(id) FROM datasources_demographicdatafeature;
   max_feature_id := max(id) FROM datasources_demographicdatafeature;
 

--- a/deployment/grid_function.sql
+++ b/deployment/grid_function.sql
@@ -59,7 +59,7 @@ BEGIN
     ALTER TABLE datasources_demographicdatafeature ADD COLUMN utm_geom geometry(MultiPolygon, 4326);
     PERFORM UpdateGeometrySRID('datasources_demographicdatafeature','utm_geom', (SELECT Find_SRID('public', 'gtfs_stops', 'geom')));
     UPDATE datasources_demographicdatafeature SET utm_geom = ST_Transform(geom, (SELECT Find_SRID('public', 'gtfs_stops', 'geom')));
-    
+
 END;
 $$ LANGUAGE plpgsql;
 

--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -408,6 +408,8 @@ pushd $PROJECT_ROOT
     sudo -u postgres psql -d $DB_NAME -f ./deployment/fishnet_function.sql
     echo 'Adding Demographic Grid PostgreSQL Function'
     sudo -u postgres psql -d $DB_NAME -f ./deployment/grid_function.sql
+    echo 'Adding PostgreSQL Function to Clip Demographics to Region Bounds'
+    sudo -u postgres psql -d $DB_NAME -f ./deployment/clip_demographics.sql
     # This needs to be run as the transit_indicators user so that it has ownership
     # over the tables, otherwise changing the SRID from GeoTrellis fails.
     echo 'Adding Shapefile reprojection PostgreSQL triggers'

--- a/python/django/datasources/tasks/shapefile.py
+++ b/python/django/datasources/tasks/shapefile.py
@@ -279,9 +279,10 @@ def run_load_shapefile_data(demographicdata_id, pop1_field, pop2_field, dest1_fi
             except ValueError as e:
                 error_factory.warn('Could not import 1 feature.', str(e))
 
-        # make raw SQL query to execute function that processes demographic data
-        # into regular point grid
+        # make raw SQL query to execute function that processes demographic data, first
+        # clipping it to region boundary, then turning it into a regular point grid
         with connection.cursor() as c:
+            c.execute('SELECT ClipDemographics();')
             c.execute('SELECT CreateGrid();')
 
         demog_data.status = DemographicDataSource.Statuses.COMPLETE


### PR DESCRIPTION
On uploading a demographics shapefile, clip its bounds to those of the region shapefile, and proportionally allocate its values based on the included area.

Here are the Philadelphia block groups, clipped to the Enterprise Zones (in green):
![image](https://cloud.githubusercontent.com/assets/960264/8289420/4bc1d114-18ea-11e5-9786-013b8140dbac.png)
