### PR TITLE
Add scrollbars to layer picker

### DIFF
--- a/js/angular/app/styles/partials/_map.scss
+++ b/js/angular/app/styles/partials/_map.scss
@@ -11,6 +11,11 @@
     }
 }
 
+.leaflet-control-layers-expanded {
+    max-height: 25rem;
+    overflow: auto;
+}
+
 .gtfs-map-controls {
     position: absolute;
     top: 1rem;


### PR DESCRIPTION
It turned out not to be possible to fiddle with the Z-index because the scenario selection control that was obscuring the layer picker is in a different stacking context from the layer picker, so I added a max height and `overflow: auto` to the layer picker instead.
![otilayerscroll](https://cloud.githubusercontent.com/assets/447977/8479380/73c1d3c2-20a5-11e5-9d36-f640137c2457.png)
