### PR TITLE
Update job accessibility percent summary units

### DIFF
--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -362,6 +362,7 @@ class Indicator(models.Model):
         JOBS_TRAVELSHED = 'jobs_travelshed'
         JOBS_ABSOLUTE_TRAVELSHED = 'jobs_absolute_travelshed'
         JOBS_PERCENTAGE_TRAVELSHED = 'jobs_percentage_travelshed'
+        JOB_PERCENTAGE_ACCESS = 'job_percentage_access'
         TRAVELSHED_POPULATION = 'population_travelshed'
 
         class Units(object):
@@ -380,6 +381,7 @@ class Indicator(models.Model):
             JOBS_ACCESSIBLE = _(u'avg jobs within x min * pop / total jobs in city.')
             JOBS_ACCESSIBLE_ABSOLUTE = _(u'jobs within x minutes')
             JOBS_ACCESSIBLE_PERCENTAGE = _(u'percent jobs within x minutes')
+            JOB_PERCENTAGE_ACCESS = _(u'percent population able to reach jobs within configured commute')
             POPULATION = _(u'population')
 
         # units of measurement for the IndicatorTypes
@@ -405,6 +407,7 @@ class Indicator(models.Model):
                             JOBS_TRAVELSHED: Units.JOBS_ACCESSIBLE,
                             JOBS_ABSOLUTE_TRAVELSHED: Units.JOBS_ACCESSIBLE_ABSOLUTE,
                             JOBS_PERCENTAGE_TRAVELSHED: Units.JOBS_ACCESSIBLE_PERCENTAGE,
+                            JOB_PERCENTAGE_ACCESS: Units.JOB_PERCENTAGE_ACCESS,
                             TRAVELSHED_POPULATION: Units.POPULATION
         }
 

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -381,7 +381,7 @@ class Indicator(models.Model):
             JOBS_ACCESSIBLE = _(u'avg jobs within x min * pop / total jobs in city.')
             JOBS_ACCESSIBLE_ABSOLUTE = _(u'jobs within x minutes')
             JOBS_ACCESSIBLE_PERCENTAGE = _(u'percent jobs within x minutes')
-            JOB_PERCENTAGE_ACCESS = _(u'percent population able to reach jobs within configured commute')
+            JOB_PERCENTAGE_ACCESS = _(u'person-accessible jobs as a percent of total jobs')
             POPULATION = _(u'population')
 
         # units of measurement for the IndicatorTypes

--- a/python/django/transit_indicators/models.py
+++ b/python/django/transit_indicators/models.py
@@ -381,7 +381,7 @@ class Indicator(models.Model):
             JOBS_ACCESSIBLE = _(u'avg jobs within x min * pop / total jobs in city.')
             JOBS_ACCESSIBLE_ABSOLUTE = _(u'jobs within x minutes')
             JOBS_ACCESSIBLE_PERCENTAGE = _(u'percent jobs within x minutes')
-            JOB_PERCENTAGE_ACCESS = _(u'person-accessible jobs as a percent of total jobs')
+            JOB_PERCENTAGE_ACCESS = _(u'population-weighted percentage of accessible jobs')
             POPULATION = _(u'population')
 
         # units of measurement for the IndicatorTypes

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/travelshed/JobsTravelshedIndicator.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/travelshed/JobsTravelshedIndicator.scala
@@ -324,7 +324,7 @@ object JobsTravelshedIndicator {
     rasterCache.set(RasterCacheKey(percentageName + cacheId), (rPercentageTile, rPercentageExtent))
 
     val basic = basicTotalJobAccessResult / tileCount
-    val percentage = basicTotalJobAccessResult / totalPopulation
+    val percentage = 100 * (basicTotalJobAccessResult / totalPopulation)
 
     new JobAccessStatistics(basic, percentage)
   }


### PR DESCRIPTION
Multiplies the indicator calculation by 100 so that it's in units of percentage, and updates the displayed percentage text (the low number here is because this is SEPTA rail and I configured the commute time to be 45 minutes).
![jobaccessunits](https://cloud.githubusercontent.com/assets/447977/8482521/248d5ade-20b8-11e5-821a-9a856258381d.png)
