### PR TITLE
Display appropriate legends for each travelshed

### DIFF
--- a/js/angular/app/index.html
+++ b/js/angular/app/index.html
@@ -20,7 +20,6 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/leaflet/dist/leaflet.css" />
     <link rel="stylesheet" href="bower_components/nvd3/src/nv.d3.css" />
-    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
     <link rel="stylesheet" href="bower_components/angular-spinkit/build/angular-spinkit.min.css" />
     <!-- endbower -->
     <!-- endbuild -->
@@ -80,7 +79,6 @@
     <script src="bower_components/leaflet-utfgrid/dist/leaflet.utfgrid.js"></script>
     <script src="bower_components/leaflet-label/dist/leaflet.label.js"></script>
     <script src="bower_components/leaflet-tilelayer-geojson/TileLayer.GeoJSON.js"></script>
-    <script src="bower_components/leaflet.draw/dist/leaflet.draw-src.js"></script>
     <script src="bower_components/d3/d3.js"></script>
     <script src="bower_components/nvd3/nv.d3.js"></script>
     <script src="bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js"></script>

--- a/js/angular/app/scripts/modules/indicators/map-controller.js
+++ b/js/angular/app/scripts/modules/indicators/map-controller.js
@@ -349,9 +349,12 @@ angular.module('transitIndicators')
         OTIMapService.getLegendData();
 
         // Set up demographic legends (static)
-        makeLegend('getTravelShedRange', 'jobsLegend', 'green8', 'MAP.JOBS_INDICATOR_TITLE');
-        makeLegend('getTravelShedRange', 'absoluteJobsLegend', 'green8', 'MAP.ABSOLUTE_JOBS_INDICATOR_TITLE');
-        makeLegend('getTravelShedRange', 'percentageJobsLegend', 'green8', 'MAP.PERCENTAGE_JOBS_INDICATOR_TITLE');
+        makeLegend('getJobsTravelShedRange', 'jobsLegend',
+                'green8', 'MAP.JOBS_INDICATOR_TITLE');
+        makeLegend('getAbsoluteJobsTravelShedRange', 'absoluteJobsLegend',
+                'green8', 'MAP.ABSOLUTE_JOBS_INDICATOR_TITLE');
+        makeLegend('getPercentageJobsTravelShedRange', 'percentageJobsLegend',
+                'green8', 'MAP.PERCENTAGE_JOBS_INDICATOR_TITLE');
         makeLegend('getPopOneRange', 'pop1Legend', 'red5', 'MAP.POPULATION_METRIC_ONE_LAYER');
         makeLegend('getPopTwoRange', 'pop2Legend', 'orange5', 'MAP.POPULATION_METRIC_TWO_LAYER');
         makeLegend('getDestOneRange', 'dest1Legend', 'blue5', 'MAP.DESTINATION_METRIC_LAYER');

--- a/js/angular/app/scripts/modules/transitmap/map-service.js
+++ b/js/angular/app/scripts/modules/transitmap/map-service.js
@@ -134,13 +134,26 @@ angular.module('transitIndicators')
     /**
      * Retrieves travel shed jobs range (min/max for legend)
      *
+     * @param type: String, Travelshed type to get (geotrellis URI path prefix)
      * @param jobId: String, job id associated with travel shed
      */
-    module.getTravelShedRange = function(jobId) {
-        return $resource('/gt/travelshed/jobs/minmax')
+    var _getTravelShedRange = function(type, jobId) {
+        return $resource('/gt/travelshed/'+ type + '/minmax')
             .get({ JOBID: jobId })
             .$promise;
     };
+
+    // External interfaces to _getTravelShedRange for different travelshed types
+    module.getJobsTravelShedRange = function(jobId) {
+        return _getTravelShedRange('jobs', jobId);
+    };
+    module.getAbsoluteJobsTravelShedRange = function(jobId) {
+        return _getTravelShedRange('abs-jobs', jobId);
+    };
+    module.getPercentageJobsTravelShedRange = function(jobId) {
+        return _getTravelShedRange('pct-jobs', jobId);
+    };
+
 
     /**
      * Retrieves demographic range

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/service/OpenTransitServiceActor.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/service/OpenTransitServiceActor.scala
@@ -71,7 +71,9 @@ trait OpenTransitService
       pathPrefix("travelshed") {
         travelshedIndicatorRoute ~
         travelshedGeotiffRoute ~
-        travelshedMinMaxRoute
+        jobsTravelshedMinMaxRoute ~
+        absoluteJobsMinMaxRoute ~
+        percentageJobsMinMaxRoute
       }
     }
 }


### PR DESCRIPTION
Previously, all travelsheds displayed the legend for the base jobs
indicator, even though the three have widely varying units.

![otiseparatepoplegends](https://cloud.githubusercontent.com/assets/447977/8484885/1576787c-20c8-11e5-99c8-01cdd3bfb895.png)

Note that the percentage legend displaying 0-0 will be fixed once #653 is merged.