### PR TITLE
Fix problem with geotiff downloads

### DIFF
--- a/js/angular/app/scripts/directives/oti-geotiff-download.js
+++ b/js/angular/app/scripts/directives/oti-geotiff-download.js
@@ -28,7 +28,7 @@ function ($document, $modal, $window, OTIIndicatorModel, OTITypes) {
                 OTITypes.getIndicatorTypes().then(function(indicators) {
                     travelshedIndicators = [];
                     _.each(indicators, function(obj, key) {
-                        if (key.endsWith('travelshed')) {
+                        if (key.match(/travelshed$/)) {
                             obj.name = key;
                             travelshedIndicators.push(obj);
                         }


### PR DESCRIPTION
Switched to match rather than endsWith, because endsWith isn't
cross-browser compatible and doesn't work in Chrome.