### PR TITLE
Transform GeoTiff to Lat/Lon before returning

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/service/TravelshedGeotiffRoute.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/service/TravelshedGeotiffRoute.scala
@@ -3,7 +3,8 @@ package com.azavea.opentransit.service
 import com.azavea.opentransit._
 
 import geotrellis.raster.io.geotiff._
-import geotrellis.proj4.LatLng
+import geotrellis.raster.reproject._
+import geotrellis.proj4.{LatLng, WebMercator}
 
 import spray.routing._
 import spray.http._
@@ -29,8 +30,10 @@ trait TravelshedGeotiffRoute extends Route { self: DatabaseInstance =>
             parameters('JOBID,
                        'INDICATOR) { (jobId, indicatorName) =>
               val geotiffBytes = Main.rasterCache.get(RasterCacheKey(indicatorName + jobId)) match {
-                case Some((tile, extent)) =>
-                    GeoTiff.render(tile, extent, LatLng, Uncompressed)
+                case Some((tile, extent)) => {
+                    val (rTile, rExtent) = tile.reproject(extent, WebMercator, LatLng)
+                    GeoTiff.render(rTile, rExtent, LatLng, Uncompressed)
+                }
                 case _ =>
                   Array[Byte]()
                 }


### PR DESCRIPTION
The rasters in the RasterCache are stored in WebMercator, but the
GeoTiff writer only supports EPSG 4326, and does not automatically
transform rasters in other projections. This was causing errors when
trying to use the downloaded GeoTiff under certain circumstances because
its actual coordinates didn't match its stated projection. This
reprojects the raster to EPSG 4326 before serving it.

Note that this doesn't transform to the selected UTM zone; that information isn't readily available in the context of the GeoTiff endpoint, so it would have been more complex to do that. However, now that the GeoTiffs' projection matches their data, it should be straightforward to process them using standard tools and reproject them to a UTM projection if necessary.