### PR TITLE
Parse direction_id, use in avg. service frequency

### DIFF
--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/Trip.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/Trip.scala
@@ -9,6 +9,7 @@ import scala.util.Try
 trait Trip {
   def id: String
   def headsign: Option[String]
+  def direction: Option[Int]
   def tripShape: Option[TripShape]
   def schedule: Seq[ScheduledStop]
 
@@ -22,6 +23,10 @@ object Trip {
     new Trip {
       def id = record.id
       def headsign = record.headsign
+      // This should be a boolean 0/1 value according to the GTFS spec, but I could
+      // imagine that being insufficient for e.g. the Green Line in Chicago,
+      // so I'm going to leave it as a simple integer.
+      def direction = record.directionId
       def tripShape = Try(tripShapes(record.tripShapeId.get)).toOption
       def schedule = scheduledStops
     }

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/TripRecord.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/TripRecord.scala
@@ -12,5 +12,6 @@ case class TripRecord (
   serviceId: ServiceId,
   routeId: RouteId,
   headsign: Option[String] = None,
+  directionId: Option[Int] = None,
   tripShapeId: Option[String] = None
 )

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/io/csv/TripsFile.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/io/csv/TripsFile.scala
@@ -1,5 +1,7 @@
 package com.azavea.gtfs.io.csv
 
+import scala.util.Try
+
 import com.azavea.gtfs._
 
 object TripsFile extends GtfsFile[TripRecord] {
@@ -13,6 +15,7 @@ object TripsFile extends GtfsFile[TripRecord] {
         t("service_id").get.intern,
         t("route_id").get.intern,
         t("trip_headsign"),
+        Try(t("direction_id").get.toInt).toOption,
         t("shape_id").map(_.intern)
       )
     }).toSeq

--- a/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/TripRecordsTable.scala
+++ b/scala/gtfs/src/main/scala/com/azavea/gtfs/io/database/TripRecordsTable.scala
@@ -13,10 +13,11 @@ trait TripRecordsTable {this: Profile  =>
     def id = column[String]("trip_id")
     def service_id = column[String]("service_id")
     def route_id = column[String]("route_id")
+    def direction_id = column[Option[Int]]("direction_id")
     def trip_headsign = column[Option[String]]("trip_headsign")
     def shape_id = column[Option[String]]("shape_id")
 
-    def * = (id, service_id, route_id, trip_headsign, shape_id) <> (TripRecord.tupled, TripRecord.unapply)
+    def * = (id, service_id, route_id, trip_headsign, direction_id, shape_id) <> (TripRecord.tupled, TripRecord.unapply)
   }
   def tripRecordsTable = TableQuery[TripRecords]
 }

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/AverageServiceFrequency.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/calculators/AverageServiceFrequency.scala
@@ -20,20 +20,32 @@ object AverageServiceFrequency extends Indicator
   def calculation(period: SamplePeriod) = {
     def map(route: Seq[Trip]): Intermediate =
       route                                         // Seq[Trip]
-        .flatMap(_.schedule).toList                 // List[ScheduledStops]
-        .groupBy(_.stop)                            // Map[Stop, List[ScheduledStops]]
-        .values.toList                              // List[List[ScheduledStop]]
+        .groupBy(_.direction).values                        // Seq[List[Trip]]
+        // Now generate a Seq[Intermediate] for each List[Trip] in the sequence, which
+        // corresponds to each direction. This prevents trips in opposite directions from
+        // being included together in the average service frequency because they will be
+        // considered separately until the very end.
         .map(
-          _.map(_.arrivalTime).sorted)              // List[List[LocalDateTime]]
-        .map {
-          _.sliding(2).toList.filter(_.size > 1).map { dt: List[LocalDateTime] =>
-            Seconds.secondsBetween(dt(0), dt(1)).getSeconds.abs
-          }.foldLeft((0.0, 0)) { case ((total, count), diff) =>
-            (total + diff, count + 1)               // Count up the interservice spaces and add up times
-          }
-        }.foldLeft((0.0, 0)) { case ((total, count), (tdiff, cdiff)) =>
-          (total + tdiff, count + cdiff)            // Sum up all counts and totals
+          _.flatMap(_.schedule).toList                   // List[ScheduledStops]
+                  .groupBy(_.stop)                          // Map[Stop, List[ScheduledStops]]
+                  .values.toList                            // List[List[ScheduledStop]]
+                  .map(
+                   _.map(_.arrivalTime).sorted)              // List[List[LocalDateTime]]
+                  .map {
+                    _.sliding(2).toList.filter(_.size > 1).map { dt: List[LocalDateTime] =>
+                      Seconds.secondsBetween(dt(0), dt(1)).getSeconds.abs
+                  }.foldLeft((0.0, 0)) { case ((total, count), diff) =>
+                    (total + diff, count + 1)               // Count up the interservice spaces and add up times
+                  }
+                  }.foldLeft((0.0, 0)) { case ((total, count), (tdiff, cdiff)) =>
+                    (total + tdiff, count + cdiff)            // Sum up all counts and totals
+                 } // (Double, Int)
+        ) // List[(Double, Int)]
+        .foldLeft((0.0, 0)) {
+          case ((totalSum, countSum), (directionTotal, directionCount)) =>
+            (totalSum + directionTotal, countSum + directionCount)
         }
+
 
     /** This takes the headway between all scheduled stops (per stop and per route)
      * and calculates average. This means that

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/ObservedStopTimes.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/parameters/ObservedStopTimes.scala
@@ -101,6 +101,7 @@ object ObservedStopTimes {
             case Some(t) => t
             case None => new Trip {
               def headsign = None
+              def direction = None
               def id = tripId
               def schedule = Nil
               def tripShape = None
@@ -115,6 +116,7 @@ object ObservedStopTimes {
         def observedTripById(tripId: String): Trip =
           new Trip {
             def headsign = None
+            def direction = None
             def id = ""
             def schedule = Nil
             def tripShape = None

--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/service/json/ScenariosGtfsRouteJsonProtocol.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/service/json/ScenariosGtfsRouteJsonProtocol.scala
@@ -128,7 +128,8 @@ object ScenariosGtfsRouteJsonProtocol extends DefaultJsonProtocol with GeoJsonSu
           val stopTimes = stopTimesJson map { js => stopTimeFormat.read(js)(tripId) }
           val freqs = freqsJson map { js => frequencyFormat.read(js)(tripId) }
           val shape = shapeFormat.read(shapeJson)(tripId)
-          val trip = TripRecord(tripId, TRIP_SERVICE_ID, routeId, headsign.convertTo[Option[String]], shape.map(_.id))
+          // The editor has no concept of a trip's direction, so it is always set to 0.
+          val trip = TripRecord(tripId, TRIP_SERVICE_ID, routeId, headsign.convertTo[Option[String]], Some(0), shape.map(_.id))
           TripTuple(trip, stopTimes, freqs, shape)
         case _ =>  throw new DeserializationException("TripTuple expected")
       }


### PR DESCRIPTION
Trips in opposite directions were causing the average service frequency
indicator (which is actually headway) to report numbers that were
roughly 50% too low when the inbound and outbound trips shared stops
as in metro or train service. Bus service was usually not affected
because bus stops are usually split between inbound and outbound service
when they are on opposite sides of the street. This parses out the
direction_id parameter from GTFS feeds, when it exists, and groups the
trips by direction_id when calculating the service frequency.

If the direction_id doesn't exist in the gtfs feed, all trips will be
grouped together, so if there are opposite direction trips which share
the same stop, the service frequency at that stop will be artificially
reduced.

Note that user-generated scenarios will not benefit from this change
because the scenario editor doesn't have any concept of trip
directionality, and therefore all trips will be grouped together.

@moradology may also want to take a look.