### PR TITLE
Use stops instead of shapes to determine SRID

### DIFF
--- a/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/SystemGeometries.scala
+++ b/scala/opentransit/src/main/scala/com/azavea/opentransit/indicators/SystemGeometries.scala
@@ -137,8 +137,8 @@ object SystemBufferGeometries {
       (for(
         route <- transitSystem.routes.headOption;
         trip <- route.trips.headOption;
-        tripShape <- trip.tripShape
-      ) yield { tripShape.line.srid }) match {
+        schedule <- trip.schedule.headOption
+      ) yield { schedule.stop.point.srid }) match {
         case Some(i) => i
         case None => sys.error(s"Transit system is required to have an SRID")
       }


### PR DESCRIPTION
The file: shapes.txt is optional, so it can't be used to determine the SRID. 
Instead, use stops, which have a geometry and are required.